### PR TITLE
[#17] feat: 공통 팝업(모달) 컴포넌트 생성

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -33,6 +33,7 @@ export default function RootLayout({
         <AskButton />
         <TopButton />
         <Footer />
+        <div id="modal-root" />
       </body>
     </html>
   );

--- a/src/components/common/Modal.tsx
+++ b/src/components/common/Modal.tsx
@@ -1,0 +1,100 @@
+"use client";
+
+import React, { useEffect, useRef, useState } from "react";
+import { createPortal } from "react-dom";
+import { twMerge } from "tailwind-merge";
+
+type TModalProps = {
+  className?: string;
+  shadow?: boolean;
+  dimmed?: boolean;
+  onClose: () => void;
+  children: React.ReactNode;
+};
+
+function ModalPortal({ children }: { children: React.ReactNode }) {
+  const [element, setElement] = useState<HTMLElement | null>(null);
+
+  useEffect(() => {
+    setElement(document.getElementById("modal-root"));
+  }, []);
+
+  if (!element) return null;
+
+  return createPortal(children, element) as JSX.Element;
+}
+
+export default function Modal({
+  className,
+  shadow,
+  dimmed,
+  onClose,
+  children,
+}: TModalProps) {
+  const modalRef = useRef<HTMLDivElement>(null);
+
+  const modalOutsideClick = (e: React.MouseEvent) => {
+    if (modalRef.current === e.target) {
+      onClose();
+    }
+  };
+
+  return (
+    <ModalPortal>
+      <div
+        ref={modalRef}
+        onClick={modalOutsideClick}
+        className={twMerge(
+          "fixed inset-0 z-10 flex h-full w-full items-center justify-center",
+          dimmed && "bg-black bg-opacity-60",
+        )}
+      >
+        <div
+          className={twMerge(
+            "relative flex flex-col items-center justify-center gap-6 rounded-[20px] bg-white p-8",
+            className,
+            shadow && "shadow-custom-shadow",
+          )}
+        >
+          {children}
+        </div>
+      </div>
+    </ModalPortal>
+  );
+}
+
+function Title({ children }: { children: React.ReactNode }) {
+  return (
+    <div className="flex justify-center p-[10px] text-2xl font-semibold text-custom-light-text dark:text-custom-dark-text">
+      {children}
+    </div>
+  );
+}
+
+function Description({ children }: { children: React.ReactNode }) {
+  return (
+    <div className="flex flex-col justify-center gap-[20px] p-[10px] text-custom-text-footer-gray">
+      {children}
+    </div>
+  );
+}
+
+function Content({ children }: { children: React.ReactNode }) {
+  return <div className="flex w-full flex-col justify-center">{children}</div>;
+}
+
+function Button({ children }: { children: React.ReactNode }) {
+  return <div className="flex justify-center gap-3">{children}</div>;
+}
+
+function Box({ children }: { children: React.ReactNode }) {
+  return (
+    <div className="flex flex-col items-center justify-center">{children}</div>
+  );
+}
+
+Modal.Title = Title;
+Modal.Desc = Description;
+Modal.Content = Content;
+Modal.Button = Button;
+Modal.Box = Box;

--- a/src/components/common/Modal.tsx
+++ b/src/components/common/Modal.tsx
@@ -45,13 +45,13 @@ export default function Modal({
         ref={modalRef}
         onClick={modalOutsideClick}
         className={twMerge(
-          "fixed inset-0 z-10 flex h-full w-full items-center justify-center",
+          "fixed inset-0 z-50 flex h-full w-full items-center justify-center",
           dimmed && "bg-black bg-opacity-60",
         )}
       >
         <div
           className={twMerge(
-            "relative flex flex-col items-center justify-center gap-6 rounded-[20px] bg-white p-8",
+            "relative flex flex-col items-center justify-center gap-6 rounded-[20px] bg-white p-8 dark:bg-custom-dark-bg",
             className,
             shadow && "shadow-custom-shadow",
           )}
@@ -80,7 +80,7 @@ function Description({ children }: { children: React.ReactNode }) {
 }
 
 function Content({ children }: { children: React.ReactNode }) {
-  return <div className="flex w-full flex-col justify-center">{children}</div>;
+  return <div className="flex flex-col justify-center">{children}</div>;
 }
 
 function Button({ children }: { children: React.ReactNode }) {

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -27,6 +27,9 @@ const config: Config = {
         "primary-purple-100": "#E0CEFF",
         "primary-purple-50": "#F2EBFF",
       },
+      boxShadow: {
+        "custom-shadow": "0px 0px 24.8px 0px rgba(0, 0, 0, 0.25)",
+      },
     },
   },
   plugins: [],


### PR DESCRIPTION
## Description
- 조합해서 사용하시기 편하게 `CCP` 패턴으로 제작했습니다. 아래 예시 참고해주세요 😆
- 기본 스타일링은 적용해뒀고, 차이 있는 부분만 `Modal`과 각 내부 아이템에 직접 `className`으로 추가해주시면 됩니다. (`Modal`의 경우 내부 `padding`, `gap` 등 / `Title`, `Desc` 등은 `text` 사이즈 등...) 
- `Modal`의 커스텀 프롭으로 `dimmed`와 `shadow`를 적용해두었습니다. 그림자/뒷배경이 필요한 경우 사용해주세요! 
- `Modal.Box`는 `Title`과 `Desc`가 함께 있지만 둘 사이에 별도의 `gap`이 존재하지 않는 경우 한 그룹으로 묶기 위해 생성했습니다. (외에도 `gap`이 필요하지 않은 두 아이템을 함께 묶을 때 사용해주세요)
```typescript
"use client";

import Modal from "@/components/common/Modal";
import { useState } from "react";

export default function Home() {
  const [modalOpen, setModalOpen] = useState(false);

  return (
    <>
      <button onClick={() => setModalOpen(true)}>모달 오픈</button>
      {modalOpen && (
        <Modal dimmed shadow onClose={() => setModalOpen(false)}>
          <Modal.Box>
            <Modal.Title>제목 부분!</Modal.Title>
            <Modal.Desc>추가 설명</Modal.Desc>
          </Modal.Box>
          <Modal.Content>컨텐츠 부분</Modal.Content>
          <Modal.Button>
            <button onClick={() => setModalOpen(false)}>닫기</button>
            <button>아무버튼</button>
          </Modal.Button>
        </Modal>
      )}
    </>
  );
}
```

## Changes Made
- `tailwind.config.ts` 파일에 `custom-shadow` 추가
- 공통 `Modal` 컴포넌트 생성 

## Screenshots
![image](https://github.com/user-attachments/assets/f3f8d80c-6dce-47b7-b221-f9b9fa65a66c)

## IssueNumber
#17 
