### PR TITLE
fix: storybook staticDirs 경로 수정 

### DIFF
--- a/.storybook/main.ts
+++ b/.storybook/main.ts
@@ -1,4 +1,5 @@
 import type { StorybookConfig } from "@storybook/nextjs";
+import path from "path";
 
 const config: StorybookConfig = {
   stories: ["../src/**/*.mdx", "../src/**/*.stories.@(js|jsx|mjs|ts|tsx)"],
@@ -12,6 +13,6 @@ const config: StorybookConfig = {
     name: "@storybook/nextjs",
     options: {},
   },
-  staticDirs: ["..\\public"],
+  staticDirs: [path.resolve(__dirname, "../public")],
 };
 export default config;


### PR DESCRIPTION
## Description
- mac, win 두 OS에서 공통적으로 사용할 수 있는 `staticDirs` 경로로 수정했습니다. 

## Changes Made
- `.storybook/main.ts` 내부 `staticDirs` 수정 

## Screenshots

## IssueNumber

