### PR TITLE
[#60] feat: 사용자 Github Repository fetch

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "0.1.0",
       "dependencies": {
         "@auth/firebase-adapter": "^2.4.2",
+        "@octokit/rest": "^21.0.2",
         "firebase": "^10.13.0",
         "firebase-admin": "^11.11.1",
         "framer-motion": "^11.3.28",
@@ -4793,6 +4794,159 @@
         "node": ">= 8"
       }
     },
+    "node_modules/@octokit/auth-token": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/@octokit/auth-token/-/auth-token-5.1.1.tgz",
+      "integrity": "sha512-rh3G3wDO8J9wSjfI436JUKzHIxq8NaiL0tVeB2aXmG6p/9859aUOAjA9pmSPNGGZxfwmaJ9ozOJImuNVJdpvbA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 18"
+      }
+    },
+    "node_modules/@octokit/core": {
+      "version": "6.1.2",
+      "resolved": "https://registry.npmjs.org/@octokit/core/-/core-6.1.2.tgz",
+      "integrity": "sha512-hEb7Ma4cGJGEUNOAVmyfdB/3WirWMg5hDuNFVejGEDFqupeOysLc2sG6HJxY2etBp5YQu5Wtxwi020jS9xlUwg==",
+      "license": "MIT",
+      "dependencies": {
+        "@octokit/auth-token": "^5.0.0",
+        "@octokit/graphql": "^8.0.0",
+        "@octokit/request": "^9.0.0",
+        "@octokit/request-error": "^6.0.1",
+        "@octokit/types": "^13.0.0",
+        "before-after-hook": "^3.0.2",
+        "universal-user-agent": "^7.0.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      }
+    },
+    "node_modules/@octokit/endpoint": {
+      "version": "10.1.1",
+      "resolved": "https://registry.npmjs.org/@octokit/endpoint/-/endpoint-10.1.1.tgz",
+      "integrity": "sha512-JYjh5rMOwXMJyUpj028cu0Gbp7qe/ihxfJMLc8VZBMMqSwLgOxDI1911gV4Enl1QSavAQNJcwmwBF9M0VvLh6Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@octokit/types": "^13.0.0",
+        "universal-user-agent": "^7.0.2"
+      },
+      "engines": {
+        "node": ">= 18"
+      }
+    },
+    "node_modules/@octokit/graphql": {
+      "version": "8.1.1",
+      "resolved": "https://registry.npmjs.org/@octokit/graphql/-/graphql-8.1.1.tgz",
+      "integrity": "sha512-ukiRmuHTi6ebQx/HFRCXKbDlOh/7xEV6QUXaE7MJEKGNAncGI/STSbOkl12qVXZrfZdpXctx5O9X1AIaebiDBg==",
+      "license": "MIT",
+      "dependencies": {
+        "@octokit/request": "^9.0.0",
+        "@octokit/types": "^13.0.0",
+        "universal-user-agent": "^7.0.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      }
+    },
+    "node_modules/@octokit/openapi-types": {
+      "version": "22.2.0",
+      "resolved": "https://registry.npmjs.org/@octokit/openapi-types/-/openapi-types-22.2.0.tgz",
+      "integrity": "sha512-QBhVjcUa9W7Wwhm6DBFu6ZZ+1/t/oYxqc2tp81Pi41YNuJinbFRx8B133qVOrAaBbF7D/m0Et6f9/pZt9Rc+tg==",
+      "license": "MIT"
+    },
+    "node_modules/@octokit/plugin-paginate-rest": {
+      "version": "11.3.3",
+      "resolved": "https://registry.npmjs.org/@octokit/plugin-paginate-rest/-/plugin-paginate-rest-11.3.3.tgz",
+      "integrity": "sha512-o4WRoOJZlKqEEgj+i9CpcmnByvtzoUYC6I8PD2SA95M+BJ2x8h7oLcVOg9qcowWXBOdcTRsMZiwvM3EyLm9AfA==",
+      "license": "MIT",
+      "dependencies": {
+        "@octokit/types": "^13.5.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "peerDependencies": {
+        "@octokit/core": ">=6"
+      }
+    },
+    "node_modules/@octokit/plugin-request-log": {
+      "version": "5.3.1",
+      "resolved": "https://registry.npmjs.org/@octokit/plugin-request-log/-/plugin-request-log-5.3.1.tgz",
+      "integrity": "sha512-n/lNeCtq+9ofhC15xzmJCNKP2BWTv8Ih2TTy+jatNCCq/gQP/V7rK3fjIfuz0pDWDALO/o/4QY4hyOF6TQQFUw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 18"
+      },
+      "peerDependencies": {
+        "@octokit/core": ">=6"
+      }
+    },
+    "node_modules/@octokit/plugin-rest-endpoint-methods": {
+      "version": "13.2.4",
+      "resolved": "https://registry.npmjs.org/@octokit/plugin-rest-endpoint-methods/-/plugin-rest-endpoint-methods-13.2.4.tgz",
+      "integrity": "sha512-gusyAVgTrPiuXOdfqOySMDztQHv6928PQ3E4dqVGEtOvRXAKRbJR4b1zQyniIT9waqaWk/UDaoJ2dyPr7Bk7Iw==",
+      "license": "MIT",
+      "dependencies": {
+        "@octokit/types": "^13.5.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "peerDependencies": {
+        "@octokit/core": ">=6"
+      }
+    },
+    "node_modules/@octokit/request": {
+      "version": "9.1.3",
+      "resolved": "https://registry.npmjs.org/@octokit/request/-/request-9.1.3.tgz",
+      "integrity": "sha512-V+TFhu5fdF3K58rs1pGUJIDH5RZLbZm5BI+MNF+6o/ssFNT4vWlCh/tVpF3NxGtP15HUxTTMUbsG5llAuU2CZA==",
+      "license": "MIT",
+      "dependencies": {
+        "@octokit/endpoint": "^10.0.0",
+        "@octokit/request-error": "^6.0.1",
+        "@octokit/types": "^13.1.0",
+        "universal-user-agent": "^7.0.2"
+      },
+      "engines": {
+        "node": ">= 18"
+      }
+    },
+    "node_modules/@octokit/request-error": {
+      "version": "6.1.4",
+      "resolved": "https://registry.npmjs.org/@octokit/request-error/-/request-error-6.1.4.tgz",
+      "integrity": "sha512-VpAhIUxwhWZQImo/dWAN/NpPqqojR6PSLgLYAituLM6U+ddx9hCioFGwBr5Mi+oi5CLeJkcAs3gJ0PYYzU6wUg==",
+      "license": "MIT",
+      "dependencies": {
+        "@octokit/types": "^13.0.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      }
+    },
+    "node_modules/@octokit/rest": {
+      "version": "21.0.2",
+      "resolved": "https://registry.npmjs.org/@octokit/rest/-/rest-21.0.2.tgz",
+      "integrity": "sha512-+CiLisCoyWmYicH25y1cDfCrv41kRSvTq6pPWtRroRJzhsCZWZyCqGyI8foJT5LmScADSwRAnr/xo+eewL04wQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@octokit/core": "^6.1.2",
+        "@octokit/plugin-paginate-rest": "^11.0.0",
+        "@octokit/plugin-request-log": "^5.3.1",
+        "@octokit/plugin-rest-endpoint-methods": "^13.0.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      }
+    },
+    "node_modules/@octokit/types": {
+      "version": "13.5.0",
+      "resolved": "https://registry.npmjs.org/@octokit/types/-/types-13.5.0.tgz",
+      "integrity": "sha512-HdqWTf5Z3qwDVlzCrP8UJquMwunpDiMPt5er+QjGzL4hqr/vBVY/MauQgS1xWxCDT1oMx1EULyqxncdCY/NVSQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@octokit/openapi-types": "^22.2.0"
+      }
+    },
     "node_modules/@panva/hkdf": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/@panva/hkdf/-/hkdf-1.2.1.tgz",
@@ -8126,6 +8280,12 @@
           "url": "https://feross.org/support"
         }
       ]
+    },
+    "node_modules/before-after-hook": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/before-after-hook/-/before-after-hook-3.0.2.tgz",
+      "integrity": "sha512-Nik3Sc0ncrMK4UUdXQmAnRtzmNQTAAXmXIopizwZ1W1t8QmfJj+zL4OA2I7XPTPW5z5TDqv4hRo/JzouDJnX3A==",
+      "license": "Apache-2.0"
     },
     "node_modules/big.js": {
       "version": "5.2.2",
@@ -19679,6 +19839,12 @@
         "type": "opencollective",
         "url": "https://opencollective.com/unified"
       }
+    },
+    "node_modules/universal-user-agent": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/universal-user-agent/-/universal-user-agent-7.0.2.tgz",
+      "integrity": "sha512-0JCqzSKnStlRRQfCdowvqy3cy0Dvtlb8xecj/H8JFZuCze4rwjPZQOgvFvn0Ws/usCHQFGpyr+pB9adaGwXn4Q==",
+      "license": "ISC"
     },
     "node_modules/universalify": {
       "version": "2.0.1",

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
   },
   "dependencies": {
     "@auth/firebase-adapter": "^2.4.2",
+    "@octokit/rest": "^21.0.2",
     "firebase": "^10.13.0",
     "firebase-admin": "^11.11.1",
     "framer-motion": "^11.3.28",

--- a/src/app/(home)/_components/HeroSection.tsx
+++ b/src/app/(home)/_components/HeroSection.tsx
@@ -31,8 +31,7 @@ export default function HeroSection() {
           </span>
         </p>
         <div className="mt-[5vh]">
-          {/* /vulnerability-db는 임시로 경로 지정 << 추후 분석하기 페이지로 작성 */}
-          <Link href={status === "authenticated" ? "/vulnerability-db" : "/login"}>
+          <Link href={status === "authenticated" ? "/mylibrary" : "/login"}>
             <Button
               theme="filled"
               size="small"

--- a/src/app/(my-repo)/_components/LibraryList.tsx
+++ b/src/app/(my-repo)/_components/LibraryList.tsx
@@ -1,53 +1,37 @@
 "use client";
 
+import { useEffect } from "react";
 import { twMerge } from "tailwind-merge";
-import { usePagination } from "../_hook/usePagination";
 import { CaretLeft, CaretRight } from "../../../../public/assets/svg/SvgIcons";
 import RoundButton from "./RoundButton";
-import { Repository } from "@/types/repository";
 import RepositoryItem from "../mylibrary/_components/RepositoryItem";
 import LibraryToolbar from "./LibraryToolbar";
 import DetectedFile from "../me/detected-files/_components/DetectedFile";
-
-const FILES = [
-  { label: "label", title: "sfacweb - 1", subtitle: "sub title", id: 1 },
-  { label: "label", title: "sfacweb - 2", subtitle: "sub title", id: 2 },
-  { label: "label", title: "sfacweb - 3", subtitle: "sub title", id: 3 },
-  { label: "label", title: "sfacweb - 4", subtitle: "sub title", id: 4 },
-  { label: "label", title: "sfacweb - 5", subtitle: "sub title", id: 5 },
-  { label: "label", title: "sfacweb - 6", subtitle: "sub title", id: 6 },
-  { label: "label", title: "sfacweb - 7", subtitle: "sub title", id: 7 },
-  { label: "label", title: "sfacweb - 8", subtitle: "sub title", id: 8 },
-  { label: "label", title: "sfacweb - 9", subtitle: "sub title", id: 9 },
-  { label: "label", title: "sfacweb - 10", subtitle: "sub title", id: 10 },
-  { label: "label", title: "sfacweb - 11", subtitle: "sub title", id: 11 },
-  { label: "label", title: "sfacweb - 12", subtitle: "sub title", id: 12 },
-  { label: "label", title: "sfacweb - 13", subtitle: "sub title", id: 13 },
-  { label: "label", title: "sfacweb - 14", subtitle: "sub title", id: 14 },
-  { label: "label", title: "sfacweb - 15", subtitle: "sub title", id: 15 },
-  { label: "label", title: "sfacweb - 16", subtitle: "sub title", id: 16 },
-  { label: "label", title: "sfacweb - 17", subtitle: "sub title", id: 17 },
-  { label: "label", title: "sfacweb - 18", subtitle: "sub title", id: 18 },
-  { label: "label", title: "sfacweb - 19", subtitle: "sub title", id: 19 },
-  { label: "label", title: "sfacweb - 20", subtitle: "sub title", id: 20 },
-];
+import { useGithubStore } from '@/store/useGithubStore';
+import { usePagination } from "../_hook/usePagination";
 
 export default function LibraryList({
   className,
   type,
-  files = FILES,
 }: {
   className?: string;
-  files?: Repository[];
   type: "REPO" | "DETECTED";
 }) {
+  const { repositories, fetchRepositories, isLoading, error } = useGithubStore();
   const {
-    currentItems: currentFiles,
+    currentItems: currentRepos,
     currentPage,
     totalPages,
     handlePrev,
     handleNext,
-  } = usePagination(files);
+  } = usePagination(repositories);
+
+  useEffect(() => {
+    fetchRepositories();
+  }, [fetchRepositories]);
+
+  if (isLoading) return <div>Loading...</div>;
+  if (error) return <div>{error}</div>;
 
   return (
     <section className="flex flex-col gap-12">
@@ -73,16 +57,21 @@ export default function LibraryList({
             className && className,
           )}
         >
-          {currentFiles &&
-            currentFiles.map((file) => (
-              <li key={file.id}>
-                {type === "REPO" ? (
-                  <RepositoryItem {...file} />
-                ) : (
-                  <DetectedFile {...file} />
-                )}
-              </li>
-            ))}
+          {currentRepos.map((repo) => (
+            <li key={repo.id}>
+              {type === "REPO" ? (
+                <RepositoryItem
+                  id={repo.id}
+                  name={repo.name}
+                  description={repo.description}
+                  visibility={repo.visibility}
+                  owner={repo.owner}
+                />
+              ) : (
+                <DetectedFile {...repo} />
+              )}
+            </li>
+          ))}
         </ul>
       </div>
     </section>

--- a/src/app/(my-repo)/me/detected-files/_components/DetectedFile.tsx
+++ b/src/app/(my-repo)/me/detected-files/_components/DetectedFile.tsx
@@ -1,23 +1,24 @@
-import { Repository } from "@/types/repository";
 import AssistChips from "@/components/common/chips/AssistChips";
 import Link from "next/link";
 import LibraryItem from "@/app/(my-repo)/_components/LibraryItem";
+import { RepositoryProps } from "@/types";
 
 export default function DetectedFile({
   id,
-  label,
-  title,
-  subtitle,
-}: Repository) {
+  name,
+  description,
+  visibility,
+  owner,
+}: RepositoryProps) {
   return (
     <Link href={`/ai-analyze/${id}`}>
       <LibraryItem className="border-primary-purple-100">
         <LibraryItem.Chip>
-          <AssistChips assistType="outlinePrimary">{label}</AssistChips>
+          <AssistChips assistType="outlinePrimary">{visibility}</AssistChips>
         </LibraryItem.Chip>
         <LibraryItem.TextBox>
-          <LibraryItem.Title>{title}</LibraryItem.Title>
-          <LibraryItem.Desc>{subtitle}</LibraryItem.Desc>
+          <LibraryItem.Title>{name}</LibraryItem.Title>
+          <LibraryItem.Desc>{description}</LibraryItem.Desc>
         </LibraryItem.TextBox>
       </LibraryItem>
     </Link>

--- a/src/app/(my-repo)/mylibrary/_components/RepositoryItem.tsx
+++ b/src/app/(my-repo)/mylibrary/_components/RepositoryItem.tsx
@@ -1,23 +1,24 @@
-import { Repository } from "@/types/repository";
 import LibraryItem from "../../_components/LibraryItem";
 import AssistChips from "@/components/common/chips/AssistChips";
 import Link from "next/link";
+import { RepositoryProps } from "@/types";
 
 export default function RepositoryItem({
   id,
-  label,
-  title,
-  subtitle,
-}: Repository) {
+  name,
+  description,
+  visibility,
+  owner,
+}: RepositoryProps) {
   return (
-    <Link href={`/ai-analyze/${id}`}>
+    <Link href={`/analyze/${owner.login}/${name}`}>
       <LibraryItem>
         <LibraryItem.Chip>
-          <AssistChips assistType="outline">{label}</AssistChips>
+          <AssistChips assistType="outline">{visibility}</AssistChips>
         </LibraryItem.Chip>
         <LibraryItem.TextBox>
-          <LibraryItem.Title>{title}</LibraryItem.Title>
-          <LibraryItem.Desc>{subtitle}</LibraryItem.Desc>
+          <LibraryItem.Title>{name}</LibraryItem.Title>
+          <LibraryItem.Desc>{description || 'No description'}</LibraryItem.Desc>
         </LibraryItem.TextBox>
       </LibraryItem>
     </Link>

--- a/src/app/(my-repo)/mylibrary/page.tsx
+++ b/src/app/(my-repo)/mylibrary/page.tsx
@@ -1,7 +1,11 @@
-export default function MyLibraryPage (){
+import LibraryList from "../_components/LibraryList";
+import UserItem from "../_components/UserItem";
+
+export default function MyLibraryPage() {
   return (
-    <>
-      <h1>MyLibraryPage</h1>
-    </>
+    <div className="px-4 py-4 md:px-[300px] md:py-12">
+      <UserItem />
+      <LibraryList type="REPO" />
+    </div>
   );
 }

--- a/src/app/api-test/analyze/[owner]/[name]/_components/FileList.tsx
+++ b/src/app/api-test/analyze/[owner]/[name]/_components/FileList.tsx
@@ -1,0 +1,13 @@
+import { RepositoryContent } from '@/types';
+
+export default function FileList({ contents }: { contents: RepositoryContent[] }) {
+  return (
+    <ul>
+      {contents.map((content) => (
+        <li key={content.sha}>
+          {content.type === 'file' ? '📄' : '📁'} {content.name}
+        </li>
+      ))}
+    </ul>
+  );
+}

--- a/src/app/api-test/analyze/[owner]/[name]/page.tsx
+++ b/src/app/api-test/analyze/[owner]/[name]/page.tsx
@@ -1,0 +1,30 @@
+'use client';
+
+import { useEffect } from 'react';
+import { useParams } from 'next/navigation';
+import { useGithubStore } from '@/store/useGithubStore';
+import FileList from './_components/FileList';
+
+export default function RepositoryPage() {
+  const params = useParams();
+  const owner = Array.isArray(params.owner) ? params.owner[0] : params.owner;
+  const name = Array.isArray(params.name) ? params.name[0] : params.name;
+
+  const { fetchRepoContents, repoContents, isLoading, error } = useGithubStore();
+
+  useEffect(() => {
+    if (owner && name) {
+      fetchRepoContents(owner, name);
+    }
+  }, [owner, name, fetchRepoContents]);
+
+  if (isLoading) return <div>Loading...</div>;
+  if (error) return <div>Error: {error}</div>;
+
+  return (
+    <div>
+      <h1>Repository: {owner}/{name}</h1>
+      <FileList contents={repoContents} />
+    </div>
+  );
+}

--- a/src/app/api-test/me/clip-article/page.tsx
+++ b/src/app/api-test/me/clip-article/page.tsx
@@ -1,0 +1,7 @@
+export default function page (){
+  return (
+    <>
+      <h1>page</h1>
+    </>
+  );
+}

--- a/src/app/api-test/me/detected-list/page.tsx
+++ b/src/app/api-test/me/detected-list/page.tsx
@@ -1,0 +1,7 @@
+export default function page (){
+  return (
+    <>
+      <h1>page</h1>
+    </>
+  );
+}

--- a/src/app/api-test/me/page.tsx
+++ b/src/app/api-test/me/page.tsx
@@ -1,0 +1,7 @@
+export default function page (){
+  return (
+    <>
+      <h1>page</h1>
+    </>
+  );
+}

--- a/src/app/api-test/me/setting/page.tsx
+++ b/src/app/api-test/me/setting/page.tsx
@@ -1,0 +1,7 @@
+export default function page (){
+  return (
+    <>
+      <h1>page</h1>
+    </>
+  );
+}

--- a/src/app/api-test/mylibrary/_components/RepoList.tsx
+++ b/src/app/api-test/mylibrary/_components/RepoList.tsx
@@ -1,0 +1,87 @@
+'use client'
+
+import { useEffect } from 'react';
+import { useSession } from 'next-auth/react';
+import { useGithubStore } from '@/store/useGithubStore';
+import { RepositoryProps, RepositoryContent } from '@/types';
+
+export default function RepoList() {
+  const { data: session } = useSession();
+  const { 
+    repositories, 
+    currentRepo,
+    currentPath,
+    repoContents, 
+    selectedFile,
+    isLoading, 
+    error, 
+    fetchRepositories, 
+    fetchRepoContents,
+    selectFile,
+    clearSelection
+  } = useGithubStore();
+
+  useEffect(() => {
+    if (session) {
+      fetchRepositories();
+    }
+  }, [session, fetchRepositories]);
+
+  const handleRepoClick = (repo: RepositoryProps) => {
+    fetchRepoContents(repo.owner.login, repo.name);
+  };
+
+  const handleContentClick = (content: RepositoryContent) => {
+    const [owner, repo] = currentRepo!.split('/');
+    if (content.type === 'dir') {
+      fetchRepoContents(owner, repo, content.path);
+    } else {
+      selectFile(owner, repo, content.path);
+    }
+  };
+
+  if (error) return <div>{error}</div>;
+
+  return (
+    <div>
+      {!currentRepo ? (
+        <ul>
+          {repositories.map((repo) => (
+            <li key={repo.id}>
+              <button onClick={() => handleRepoClick(repo)}>
+                {repo.name}
+              </button>
+            </li>
+          ))}
+        </ul>
+      ) : (
+        <div>
+          <h3>{currentRepo}{currentPath && `: ${currentPath}`}</h3>
+          <button onClick={() => {
+            const [owner, repo] = currentRepo.split('/');
+            fetchRepoContents(owner, repo, '');
+          }}>
+            Root
+          </button>
+          <ul>
+            {repoContents.map((content) => (
+              <li key={content.sha}>
+                <button onClick={() => handleContentClick(content)}>
+                  {content.type === 'file' ? '📄' : '📁'} {content.name}
+                </button>
+              </li>
+            ))}
+          </ul>
+        </div>
+      )}
+
+      {selectedFile && (
+        <div>
+          <h4>File: {selectedFile.path}</h4>
+          <pre>{selectedFile.content || 'Loading...'}</pre>
+          <button onClick={clearSelection}>Close File</button>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/app/api-test/mylibrary/page.tsx
+++ b/src/app/api-test/mylibrary/page.tsx
@@ -1,0 +1,23 @@
+import { cookies } from "next/headers";
+import Image from "next/image";
+import RepoList from "./_components/RepoList";
+
+
+export default async function MyLibraryPage() {
+  const cookieStore = cookies();
+  const sessionToken = cookieStore.get("next-auth.session-token");
+
+  if (!sessionToken) {
+    return (
+      <section className="relative flex w-full h-[84vh] text-primary-purple-500 overflow-hidden dark:text-purple-50 dark:font-bold z-20">
+        <div>로그인</div>
+      </section>
+    );
+  }
+
+  return (
+    <div className="container">
+      <RepoList />
+    </div>
+  );
+}

--- a/src/app/api/github/contents/route.ts
+++ b/src/app/api/github/contents/route.ts
@@ -1,0 +1,36 @@
+import { NextResponse } from 'next/server';
+import { getServerSession } from "next-auth/next";
+import { authOptions } from "@/lib/auth";
+
+export async function GET(request: Request) {
+  const session = await getServerSession(authOptions);
+
+  if (!session || !session.accessToken) {
+    return NextResponse.json({ error: "Not authenticated" }, { status: 401 });
+  }
+
+  const { searchParams } = new URL(request.url);
+  const owner = searchParams.get('owner');
+  const repo = searchParams.get('repo');
+  const path = searchParams.get('path') || '';
+
+  if (!owner || !repo) {
+    return NextResponse.json({ error: "Missing owner or repo" }, { status: 400 });
+  }
+
+  try {
+    const response = await fetch(`https://api.github.com/repos/${owner}/${repo}/contents/${path}`, {
+      headers: {
+        Authorization: `token ${session.accessToken}`,
+        Accept: 'application/vnd.github.v3+json',
+      },
+    });
+
+    if (!response.ok) throw new Error('GitHub API 요청 실패');
+  
+    const data = await response.json();
+    return NextResponse.json(data);
+  } catch (error) {
+    return NextResponse.json({ error: "Failed to fetch repository contents" }, { status: 500 });
+  }
+}

--- a/src/app/api/github/file/route.ts
+++ b/src/app/api/github/file/route.ts
@@ -1,0 +1,38 @@
+import { NextResponse } from 'next/server';
+import { getServerSession } from "next-auth/next";
+import { authOptions } from "@/lib/auth";
+
+export async function GET(request: Request) {
+  const session = await getServerSession(authOptions);
+
+  if (!session || !session.accessToken) {
+    return NextResponse.json({ error: "Not authenticated" }, { status: 401 });
+  }
+
+  const { searchParams } = new URL(request.url);
+  const owner = searchParams.get('owner');
+  const repo = searchParams.get('repo');
+  const path = searchParams.get('path');
+
+  if (!owner || !repo || !path) {
+    return NextResponse.json({ error: "Missing owner, repo, or path" }, { status: 400 });
+  }
+
+  try {
+    const response = await fetch(`https://api.github.com/repos/${owner}/${repo}/contents/${path}`, {
+      headers: {
+        Authorization: `token ${session.accessToken}`,
+        Accept: 'application/vnd.github.v3+json',
+      },
+    });
+
+    if (!response.ok) {
+      throw new Error('GitHub API request failed');
+    }
+
+    const data = await response.json();
+    return NextResponse.json(data);
+  } catch (error) {
+    return NextResponse.json({ error: "Failed to fetch file content" }, { status: 500 });
+  }
+}

--- a/src/app/api/github/repositories/route.ts
+++ b/src/app/api/github/repositories/route.ts
@@ -1,0 +1,21 @@
+import { NextResponse } from 'next/server';
+import { getServerSession } from "next-auth/next";
+import { authOptions } from "@/lib/auth";
+import { getRepositories } from '@/lib/api/github';
+
+export async function GET() {
+  const session = await getServerSession(authOptions);
+  console.log("Session:", JSON.stringify(session, null, 2));
+
+  if (!session || !session.accessToken) {
+    return NextResponse.json({ error: "Not authenticated" }, { status: 401 });
+  }
+
+  try {
+    const repositories = await getRepositories(session.accessToken);
+    return NextResponse.json(repositories);
+  } catch (error) {
+    console.error('Error fetching:', error);
+    return NextResponse.json({ error: "Failed to fetch repositories" }, { status: 500 });
+  }
+}

--- a/src/app/vulnerability-db/page.tsx
+++ b/src/app/vulnerability-db/page.tsx
@@ -1,7 +1,6 @@
-export default function Vulnerability (){
+export default function Vulnerability() {
   return (
-    <>
-      
-    </>
+    <div>
+    </div>
   );
 }

--- a/src/components/common/Dropdown.tsx
+++ b/src/components/common/Dropdown.tsx
@@ -22,7 +22,7 @@ const Dropdown: React.FC<DropdownProps> = ({ type }) => {
   };
 
   return (
-    <div className="relative inline-block text-left" style={{ width: '120px' }}>
+    <div className="relative inline-block text-left z-10" style={{ width: '120px' }}>
       <div>
         <button
           type="button"
@@ -30,7 +30,7 @@ const Dropdown: React.FC<DropdownProps> = ({ type }) => {
             "w-full flex items-center gap-1 justify-between rounded-lg border shadow-sm px-[13px] py-[10px] text-sm focus:outline-none",
             "border-custom-dropdown-light-border bg-custom-dropdown-light-bg dark:bg-custom-dropdown-dark-bg",
             "text-custom-light-text dark:text-custom-dark-text",
-            "hover:bg-gray-50"
+            "hover:bg-gray-50",
           )}
           onClick={() => setIsOpen(!isOpen)}
         >

--- a/src/components/common/Header.tsx
+++ b/src/components/common/Header.tsx
@@ -1,9 +1,11 @@
-'use client'
+// src/components/common/Header.tsx
+'use client';
 
 import { useTheme } from "next-themes";
 import { Aldrich } from "next/font/google";
 import Image from "next/image";
 import React, { useEffect, useState } from "react";
+import { usePathname } from "next/navigation"; 
 import icons from "../../../public/assets/icons";
 import {
   DarkModeIcon,
@@ -20,6 +22,7 @@ const Header: React.FC = () => {
   const { theme, setTheme } = useTheme();
   const { data: session, status } = useSession();
   const [mounted, setMounted] = useState(false);
+  const pathname = usePathname(); 
 
   useEffect(() => {
     setMounted(true);
@@ -56,7 +59,7 @@ const Header: React.FC = () => {
           <span>MY 저장소</span>
 
           {status === "authenticated" && (
-            <span className="cursor-pointer hover:text-accent-blue" onClick={() => signOut({ callbackUrl: '/' })}>
+            <span className="cursor-pointer hover:text-accent-blue" onClick={() => signOut({ callbackUrl: pathname })}>
               로그아웃
             </span>
           )}

--- a/src/lib/api/github.ts
+++ b/src/lib/api/github.ts
@@ -1,0 +1,43 @@
+import { Octokit } from "@octokit/rest";
+
+export async function getRepositories(accessToken: string) {
+  console.log("Access Token:", accessToken.substring(0, 10) + "...");
+  const octokit = new Octokit({ auth: accessToken });
+
+  const { data: user } = await octokit.rest.users.getAuthenticated();
+  console.log("Authenticated user:", user.login);
+
+  try {
+    const publicRepos = await octokit.paginate(
+      octokit.rest.repos.listForAuthenticatedUser,
+      {
+        visibility: "public",
+        sort: "updated",
+        per_page: 100,
+      },
+    );
+    console.log("Public repos count:", publicRepos.length);
+
+    const privateRepos = await octokit.paginate(
+      octokit.rest.repos.listForAuthenticatedUser,
+      {
+        visibility: "private",
+        sort: "updated",
+        per_page: 100,
+      },
+    );
+    console.log("Private repos count:", privateRepos.length);
+
+    const allRepos = [...publicRepos, ...privateRepos].sort((a, b) => {
+      const dateA = a.updated_at ? new Date(a.updated_at) : new Date(0);
+      const dateB = b.updated_at ? new Date(b.updated_at) : new Date(0);
+      return dateB.getTime() - dateA.getTime();
+    });
+    console.log("레퍼지토리 전체 목록", allRepos);
+
+    return allRepos;
+  } catch (error) {
+    console.error("Error fetching repositories:", error);
+    throw error;
+  }
+}

--- a/src/store/useGithubStore.ts
+++ b/src/store/useGithubStore.ts
@@ -1,0 +1,61 @@
+import { create } from "zustand";
+import { RepositoryState } from "@/types";
+
+
+export const useGithubStore = create<RepositoryState>((set, get) => ({
+  repositories: [],
+  currentRepo: null,
+  currentPath: '',
+  repoContents: [],
+  selectedFile: null,
+  isLoading: false,
+  error: null,
+
+  fetchRepositories: async () => {
+    set({ isLoading: true, error: null });
+    try {
+      const response = await fetch("/api/github/repositories");
+      if (!response.ok) throw new Error("Failed to fetch repositories");
+      const data = await response.json();
+      set({ repositories: data, isLoading: false });
+    } catch (error) {
+      set({ error: (error as Error).message, isLoading: false });
+    }
+  },
+
+  fetchRepoContents: async (owner: string, repo: string, path: string = '') => {
+    set({ isLoading: true, error: null });
+    try {
+      const response = await fetch(`/api/github/contents?owner=${owner}&repo=${repo}&path=${path}`);
+      if (!response.ok) throw new Error("Failed to fetch repository contents");
+      const data = await response.json();
+      set({ 
+        currentRepo: `${owner}/${repo}`,
+        currentPath: path,
+        repoContents: data, 
+        isLoading: false 
+      });
+    } catch (error) {
+      set({ error: (error as Error).message, isLoading: false });
+    }
+  },
+
+  selectFile: async (owner: string, repo: string, path: string) => {
+    set({ isLoading: true, error: null });
+    try {
+      const response = await fetch(`/api/github/file?owner=${owner}&repo=${repo}&path=${path}`);
+      if (!response.ok) throw new Error("Failed to fetch file content");
+      const data = await response.json();
+      set({ 
+        selectedFile: { ...data, content: atob(data.content) },
+        isLoading: false 
+      });
+    } catch (error) {
+      set({ error: (error as Error).message, isLoading: false });
+    }
+  },
+
+  clearSelection: () => {
+    set({ selectedFile: null });
+  }
+}));

--- a/src/types/github-repos.d.ts
+++ b/src/types/github-repos.d.ts
@@ -1,0 +1,48 @@
+export type RepositoryProps = {
+  id: number;
+  name: string;
+  // html_url: string;
+  owner: {
+    login: string;
+  };
+  visibility: "public" | "private";
+  description: string | null;
+  /* 추후 필요한 필드 추가 */
+};
+
+export type RepositoryContent = {
+  name: string;
+  path: string;
+  sha: string;
+  size: number;
+  url: string;
+  html_url: string;
+  git_url: string;
+  download_url: string | null;
+  type: "file" | "dir" | "symlink" | "submodule";
+  content?: string;
+  encoding?: string;
+};
+
+export type FileContent = RepositoryContent & {
+  content: string;
+};
+
+export type RepositoryState = {
+  repositories: RepositoryProps[];
+  currentRepo: string | null;
+  currentPath: string;
+  repoContents: RepositoryContent[];
+  selectedFile: FileContent | null;
+  isLoading: boolean;
+  error: string | null;
+
+  fetchRepositories: () => Promise<void>;
+  fetchRepoContents: (
+    owner: string,
+    repo: string,
+    path?: string,
+  ) => Promise<void>;
+  selectFile: (owner: string, repo: string, path: string) => Promise<void>;
+  clearSelection: () => void;
+};

--- a/src/types/index.d.ts
+++ b/src/types/index.d.ts
@@ -1,3 +1,5 @@
 export * from "./utils";
 export * from "./inquiry";
 export * from "./chips";
+export * from "./next-auth";
+export * from "./github-repos";

--- a/src/types/next-auth.d.ts
+++ b/src/types/next-auth.d.ts
@@ -1,0 +1,7 @@
+import type { DefaultSession } from 'next-auth'
+
+declare module 'next-auth' {
+  interface Session extends DefaultSession {
+    accessToken?: string
+  }
+}

--- a/src/types/repository.d.ts
+++ b/src/types/repository.d.ts
@@ -1,6 +1,0 @@
-export type Repository = {
-  label: string;
-  title: string;
-  subtitle: string;
-  id: number;
-};


### PR DESCRIPTION
## Description
- 아름님이 작성하신 목업 레퍼지토리 리스트에 사용자의 Repository Fetch
- `api-test` 라는 목업 경로에 레퍼지토리 출력 및 해당 레퍼지토리의 파일 출력 예시 코드 작성
-  `api-test` 디렉토리 코드는 예시라 추후 목업에 합칠 때 수정 필요

## Changes Made
- Auth.js의 GithubProvider의 Scope : repo 추가 -> private 레퍼지토리도 가져올 수 있게 함
## 로그인 한 사용자의 원격 저장소 목록
<img width="2168" alt="image" src="https://github.com/user-attachments/assets/269790ce-2073-47ad-8e13-da1758e340fd">

## 선택한 레퍼지토리의 디렉토리 구조
<img width="2168" alt="image" src="https://github.com/user-attachments/assets/5b482226-1299-4925-8e78-6439cda27f71">
