### PR TITLE
[#70] fix: repos 페이지 db 및 filter 로직 수정, 리팩토링 

### DIFF
--- a/src/app/repos/_components/BookmarkButton.tsx
+++ b/src/app/repos/_components/BookmarkButton.tsx
@@ -4,24 +4,20 @@ import { useMemo, useState } from "react";
 import { StarFilled, StarLined } from "../../../../public/assets/svg/SvgIcons";
 import { twMerge } from "tailwind-merge";
 import { postRepo } from "../_utils/fetchRepos";
-import { useSession } from "next-auth/react";
 import { debounce } from "@/utils/debounce";
+import { useGetUser } from "@/hooks/useGetUser";
 
 export default function BookmarkButton({
   bookmark,
-  id,
   name,
 }: {
   bookmark: boolean | undefined;
-  id: number;
   name: string;
 }) {
   const [isBookmarked, setIsBookmarked] = useState<boolean | undefined>(
     bookmark,
   );
-  // const { setRepositories } = useGithubStore();
-  const { data } = useSession();
-  const email = data?.user?.email ?? "";
+  const { email } = useGetUser();
 
   const debounceUpdateBookmark = useMemo(
     () =>
@@ -39,8 +35,10 @@ export default function BookmarkButton({
   ) => {
     e.preventDefault();
     try {
-      setIsBookmarked((prev) => !prev);
-      await debounceUpdateBookmark(email, name, { bookmark: !isBookmarked });
+      if (email) {
+        setIsBookmarked((prev) => !prev);
+        await debounceUpdateBookmark(email, name, { bookmark: !isBookmarked });
+      }
     } catch (error) {
       setIsBookmarked((prev) => prev);
       console.log(error);

--- a/src/app/repos/_components/DetectLink.tsx
+++ b/src/app/repos/_components/DetectLink.tsx
@@ -9,13 +9,11 @@ import { RepositoryStatus } from "@/types";
 
 export default function DetectLink({
   status,
-  id,
   owner,
   name,
   recent,
 }: {
   status?: RepositoryStatus;
-  id: number;
   owner: string;
   name: string;
   recent?: boolean;

--- a/src/app/repos/_components/DetectLink.tsx
+++ b/src/app/repos/_components/DetectLink.tsx
@@ -1,18 +1,28 @@
+"use client";
+
 import Link from "next/link";
 import { twMerge } from "tailwind-merge";
 import { Bug, CaretRight } from "../../../../public/assets/svg/SvgIcons";
+import { postRepo } from "../_utils/fetchRepos";
+import { useSession } from "next-auth/react";
+import { RepositoryStatus } from "@/types";
 
 export default function DetectLink({
   status,
   id,
   owner,
   name,
+  recent,
 }: {
-  status?: "COMPLETED" | "IN_PROGRESS" | undefined;
+  status?: RepositoryStatus;
   id: number;
   owner: string;
   name: string;
+  recent?: boolean;
 }) {
+  const { data } = useSession();
+  const email = data?.user?.email ?? "";
+
   let style;
   switch (status) {
     case "COMPLETED":
@@ -22,6 +32,12 @@ export default function DetectLink({
       style = "bg-primary-purple-500";
       break;
   }
+
+  const handleClickRepo = async () => {
+    if (!recent) {
+      await postRepo(email, name, { recent: true });
+    }
+  };
 
   return (
     <Link
@@ -36,6 +52,7 @@ export default function DetectLink({
           "flex items-center gap-[7px] whitespace-nowrap rounded-[14px] p-[10px] text-white",
           style,
         )}
+        onClick={handleClickRepo}
       >
         <Bug />
         {status === "COMPLETED" ? "결과보기" : "검사하기"}

--- a/src/app/repos/_components/LogoutConfirmModal.tsx
+++ b/src/app/repos/_components/LogoutConfirmModal.tsx
@@ -1,28 +1,22 @@
 import Button from "@/components/common/Button";
 import Modal from "@/components/common/Modal";
 import { SignOut } from "../../../../public/assets/svg/SvgIcons";
-import { useGithubStore } from "@/store/useGithubStore";
-import { signOut } from "next-auth/react";
+import { customSignOut } from "@/lib/customAuth";
+import { useGetUser } from "@/hooks/useGetUser";
 
-/**
- *
- * @todo
- * - 로그아웃 로직에 user 삭제 추가
- *
- */
-
-export default function LogoutComfirmModal({
+export default function LogoutConfirmModal({
   isOpen,
   onClose,
 }: {
   isOpen: boolean;
   onClose: React.Dispatch<React.SetStateAction<boolean>>;
 }) {
-  const clearRepoStorage = useGithubStore.persist.clearStorage;
+  const { email } = useGetUser();
 
   const handleLogout = () => {
-    clearRepoStorage();
-    signOut({ redirect: true, callbackUrl: "/" });
+    if (email) {
+      customSignOut(email, "/");
+    }
   };
 
   return (

--- a/src/app/repos/_components/ReposFilterButtons.tsx
+++ b/src/app/repos/_components/ReposFilterButtons.tsx
@@ -54,9 +54,10 @@ export default function ReposFilterButtons({
     <div className="flex gap-[21px]">
       {REPO_FILTER_BUTTONS.map((button) => (
         <Button
+          key={button.label}
           theme="outlined"
           className={twMerge(
-            "text-text-gray-dark w-full gap-[10px] border-line-gray-10 p-4 text-xl hover:bg-transparent hover:shadow-sm focus:border-line-gray-10 focus:bg-transparent active:border-line-default dark:border-opacity-20 dark:text-text-gray-light sm:p-4 sm:text-xl md:p-4 md:text-xl",
+            "w-full gap-[10px] border-line-gray-10 p-4 text-xl text-text-gray-dark hover:bg-transparent hover:shadow-sm focus:border-line-gray-10 focus:bg-transparent active:border-line-default dark:border-opacity-20 dark:text-text-gray-light sm:p-4 sm:text-xl md:p-4 md:text-xl",
             libraryState[button.name] && selectStyle,
           )}
           onClick={(e) => {

--- a/src/app/repos/_components/ReposFilterButtons.tsx
+++ b/src/app/repos/_components/ReposFilterButtons.tsx
@@ -4,14 +4,27 @@ import Button from "@/components/common/Button";
 import { Bookmark, RecentFile } from "../../../../public/assets/svg/SvgIcons";
 import { RepositoryProps } from "@/types";
 import { filterRepos } from "../_utils/filterRepos";
-import { useEffect, useState } from "react";
+import { useEffect } from "react";
 import { twMerge } from "tailwind-merge";
 import { useLibraryStore } from "@/store/useLibraryStore";
+import { FilterType } from "@/types/library";
 
-type TFilterType = {
-  recent: boolean;
-  bookmark: boolean;
-};
+const REPO_FILTER_BUTTONS: Array<{
+  name: keyof FilterType;
+  label: string;
+  icon: JSX.Element;
+}> = [
+  {
+    name: "recent",
+    label: "Recents File",
+    icon: <RecentFile color="dark:fill-text-gray-light" />,
+  },
+  {
+    name: "bookmark",
+    label: "Bookmark",
+    icon: <Bookmark color="dark:fill-text-gray-light" />,
+  },
+];
 
 export default function ReposFilterButtons({
   setRepos,
@@ -20,20 +33,16 @@ export default function ReposFilterButtons({
   setRepos: React.Dispatch<React.SetStateAction<RepositoryProps[]>>;
   repositories: RepositoryProps[];
 }) {
-  // const [isSelect, setIsSelect] = useState<TFilterType>({
-  //   recent: false,
-  //   bookmark: false,
-  // });
-  const { libraryState, setLibraryState } = useLibraryStore();
+  const { libraryState, reposData, setLibraryState } = useLibraryStore();
   const selectStyle =
     "bg-bg-purple-light hover:bg-bg-purple-light focus:bg-bg-purple-light dark:bg-bg-purple-light dark:bg-opacity-10";
 
   const handleFilterRepos = (e: React.MouseEvent<HTMLButtonElement>) => {
-    const type = e.currentTarget.name as keyof TFilterType;
+    const type = e.currentTarget.name as keyof FilterType;
     if (libraryState[type]) {
       setRepos(repositories);
     } else {
-      filterRepos(type, setRepos, repositories);
+      filterRepos(type, setRepos, repositories, reposData);
     }
   };
 
@@ -43,40 +52,26 @@ export default function ReposFilterButtons({
 
   return (
     <div className="flex gap-[21px]">
-      <Button
-        theme="outlined"
-        className={twMerge(
-          "w-full gap-[10px] border-line-gray-10 p-4 text-xl text-text-gray-dark hover:bg-transparent hover:shadow-sm focus:border-line-gray-10 focus:bg-transparent active:border-line-default dark:border-opacity-20 dark:text-text-gray-light sm:p-4 sm:text-xl md:p-4 md:text-xl",
-          libraryState.recent && selectStyle,
-        )}
-        onClick={(e) => {
-          handleFilterRepos(e);
-          setLibraryState({
-            recent: !libraryState.recent,
-            bookmark: false,
-          });
-        }}
-        name="recent"
-      >
-        <RecentFile color="dark:fill-text-gray-light" /> Recents File
-      </Button>
-      <Button
-        theme="outlined"
-        className={twMerge(
-          "w-full gap-[10px] border-line-gray-10 p-4 text-xl text-text-gray-dark hover:bg-transparent hover:shadow-sm focus:border-line-gray-10 focus:bg-transparent active:border-line-default dark:border-opacity-20 dark:text-text-gray-light sm:p-4 sm:text-xl md:p-4 md:text-xl",
-          libraryState.bookmark && selectStyle,
-        )}
-        onClick={(e) => {
-          handleFilterRepos(e);
-          setLibraryState({
-            recent: false,
-            bookmark: !libraryState.bookmark,
-          });
-        }}
-        name="bookmark"
-      >
-        <Bookmark color="dark:fill-text-gray-light" /> Bookmark
-      </Button>
+      {REPO_FILTER_BUTTONS.map((button) => (
+        <Button
+          theme="outlined"
+          className={twMerge(
+            "text-text-gray-dark w-full gap-[10px] border-line-gray-10 p-4 text-xl hover:bg-transparent hover:shadow-sm focus:border-line-gray-10 focus:bg-transparent active:border-line-default dark:border-opacity-20 dark:text-text-gray-light sm:p-4 sm:text-xl md:p-4 md:text-xl",
+            libraryState[button.name] && selectStyle,
+          )}
+          onClick={(e) => {
+            handleFilterRepos(e);
+            setLibraryState({
+              recent: button.name === "recent" ? !libraryState.recent : false,
+              bookmark:
+                button.name === "bookmark" ? !libraryState.bookmark : false,
+            });
+          }}
+          name={button.name}
+        >
+          {button.icon} {button.label}
+        </Button>
+      ))}
     </div>
   );
 }

--- a/src/app/repos/_components/ReposToolbar.tsx
+++ b/src/app/repos/_components/ReposToolbar.tsx
@@ -3,7 +3,7 @@
 import ReposFilterButtons from "./ReposFilterButtons";
 import { RepositoryProps } from "@/types";
 import { useState } from "react";
-import { useFilterRepos } from "../../../hooks/useFilterItems";
+import { useFilterReposType } from "../../../hooks/useFilterItems";
 import LibraryToolbar, { TDropdownSelect } from "./LibraryToolbar";
 
 export default function ReposToolbar({
@@ -19,7 +19,7 @@ export default function ReposToolbar({
   });
   const typeOptions = ["전체", "검사완료", "검사중"];
 
-  useFilterRepos(selectedItem, setRepos, repositories);
+  useFilterReposType(selectedItem, setRepos, repositories);
 
   return (
     <div className="flex flex-col gap-12">

--- a/src/app/repos/_components/RepositoryItem.tsx
+++ b/src/app/repos/_components/RepositoryItem.tsx
@@ -15,7 +15,6 @@ type TRepositoryItemProps = {
 } & RepositoryProps;
 
 export default function RepositoryItem({
-  id,
   name,
   owner,
   created_at,
@@ -31,7 +30,7 @@ export default function RepositoryItem({
               {name}
             </h4>
           )}
-          <BookmarkButton bookmark={matchData?.bookmark} id={id} name={name} />
+          <BookmarkButton bookmark={matchData?.bookmark} name={name} />
         </div>
         {matchData?.status && (
           <h4 className="text-text-gray-dark max-w-[270px] truncate text-[28px] font-medium dark:text-text-gray-light">
@@ -41,7 +40,6 @@ export default function RepositoryItem({
       </div>
       <div className="flex items-end justify-between">
         <DetectLink
-          id={id}
           status={matchData?.status}
           recent={matchData?.recent}
           owner={owner.login}

--- a/src/app/repos/_components/RepositoryItem.tsx
+++ b/src/app/repos/_components/RepositoryItem.tsx
@@ -1,37 +1,52 @@
-import { RepositoryProps } from "@/types";
+"use client";
+
+import { RepositoryProps, RepositoryStatus } from "@/types";
 import RepositoryChip from "./RepositoryChip";
 import BookmarkButton from "./BookmarkButton";
 import { format } from "date-fns";
 import DetectLink from "./DetectLink";
 
+type TRepositoryItemProps = {
+  matchData?: {
+    bookmark?: boolean;
+    recent?: boolean;
+    status?: RepositoryStatus;
+  };
+} & RepositoryProps;
+
 export default function RepositoryItem({
   id,
   name,
-  status,
   owner,
   created_at,
-  bookmark,
-}: RepositoryProps) {
+  matchData,
+}: TRepositoryItemProps) {
   return (
     <div className="group flex h-[225px] w-full flex-col justify-between rounded-xl border border-primary-purple-100 p-5 hover:bg-bg-purple-light dark:border-opacity-20 dark:bg-custom-light-bg dark:bg-opacity-0 hover:dark:bg-opacity-5">
       <div className="flex flex-col gap-1">
         <div className="flex w-full items-center justify-between">
-          {status && <RepositoryChip type={status} />}
-          {!status && (
+          {matchData?.status && <RepositoryChip type={matchData?.status} />}
+          {!matchData?.status && (
             <h4 className="text-text-gray-dark max-w-[270px] truncate text-[28px] font-medium dark:text-text-gray-light">
               {name}
             </h4>
           )}
-          <BookmarkButton bookmark={bookmark} id={id} name={name} />
+          <BookmarkButton bookmark={matchData?.bookmark} id={id} name={name} />
         </div>
-        {status && (
+        {matchData?.status && (
           <h4 className="text-text-gray-dark max-w-[270px] truncate text-[28px] font-medium dark:text-text-gray-light">
             name
           </h4>
         )}
       </div>
       <div className="flex items-end justify-between">
-      <DetectLink id={id} status={status} owner={owner.login} name={name} />
+        <DetectLink
+          id={id}
+          status={matchData?.status}
+          recent={matchData?.recent}
+          owner={owner.login}
+          name={name}
+        />
         <span className="whitespace-nowrap text-base font-medium tracking-tight text-text-gray-default">
           {format(created_at, "yy.MM.dd")}
         </span>

--- a/src/app/repos/_components/RepositoryList.tsx
+++ b/src/app/repos/_components/RepositoryList.tsx
@@ -8,9 +8,8 @@ import Pagination from "@/app/vuldb/_components/Pagination";
 import usePaginationStore from "@/store/usePaginationStore";
 import { RepositoryProps } from "@/types";
 import ReposToolbar from "./ReposToolbar";
-// import { useSession } from "next-auth/react";
-// import { doc, getDoc } from "firebase/firestore";
-// import { db } from "@/lib/firebase";
+import { useSession } from "next-auth/react";
+import { useLibraryStore } from "@/store/useLibraryStore";
 
 export default function RepositoryList({ className }: { className?: string }) {
   const [repos, setRepos] = useState<RepositoryProps[]>([]);
@@ -20,35 +19,23 @@ export default function RepositoryList({ className }: { className?: string }) {
   );
   const { repositories, fetchRepositories, isLoading, error } =
     useGithubStore();
+  const { status, reposData, fetchReposData } = useLibraryStore();
   const { reposItemsPerPage } = usePaginationStore();
+  const { data } = useSession();
+  const email = data?.user?.email ?? "";
 
-  // const getBookmark = async (email: string) => {
-  //   const userRef = doc(db, "users", "foottable@gmail.com");
-  //   const user = await getDoc(userRef);
-  //   const bookmark = await user.data()?.bookmark;
-  //   return bookmark;
-  // };
-  // const addBookmark = (repos: RepositoryProps[], bookmarkRepos: string[]) => {
-  //   return repos.map((repo) => {
-  //     if (bookmarkRepos.includes(repo.name)) {
-  //       return { ...repo, bookmark: true };
-  //     }
-  //     return repo;
-  //   });
-  // };
+  const findMatchData = (name: string) =>
+    reposData.find((repo) => repo.id === name);
 
   useEffect(() => {
-    const githubStorage = JSON.parse(
-      localStorage.getItem("githubStorage") ?? "null",
-    );
-    if (
-      repositories.length === 0 &&
-      !githubStorage?.state?.repositories.length
-    ) {
-      fetchRepositories();
+    if (email) {
+      fetchReposData(email);
     }
-    setRepos(repositories);
-  }, [fetchRepositories, setRepos]);
+  }, [email]);
+
+  useEffect(() => {
+    fetchRepositories();
+  }, [fetchRepositories]);
 
   useEffect(() => {
     const startIndex = (currentPage - 1) * reposItemsPerPage;
@@ -68,11 +55,14 @@ export default function RepositoryList({ className }: { className?: string }) {
           className && className,
         )}
       >
-        {currentPageRepos.map((repo) => (
-          <li key={repo.id}>
-            <RepositoryItem {...repo} />
-          </li>
-        ))}
+        {currentPageRepos.map((repo) => {
+          const matchData = findMatchData(repo.name);
+          return (
+            <li key={repo.name}>
+              <RepositoryItem {...repo} matchData={matchData} />
+            </li>
+          );
+        })}
         {repos.length === 0 && (
           <p>조건에 해당하는 데이터가 존재하지 않습니다.</p>
         )}

--- a/src/app/repos/_components/RepositoryList.tsx
+++ b/src/app/repos/_components/RepositoryList.tsx
@@ -31,7 +31,7 @@ export default function RepositoryList({ className }: { className?: string }) {
     if (email) {
       fetchReposData(email);
     }
-  }, [email]);
+  }, [email, fetchReposData]);
 
   useEffect(() => {
     fetchRepositories();

--- a/src/app/repos/_components/RepositoryList.tsx
+++ b/src/app/repos/_components/RepositoryList.tsx
@@ -8,8 +8,8 @@ import Pagination from "@/app/vuldb/_components/Pagination";
 import usePaginationStore from "@/store/usePaginationStore";
 import { RepositoryProps } from "@/types";
 import ReposToolbar from "./ReposToolbar";
-import { useSession } from "next-auth/react";
 import { useLibraryStore } from "@/store/useLibraryStore";
+import { useGetUser } from "@/hooks/useGetUser";
 
 export default function RepositoryList({ className }: { className?: string }) {
   const [repos, setRepos] = useState<RepositoryProps[]>([]);
@@ -21,8 +21,7 @@ export default function RepositoryList({ className }: { className?: string }) {
     useGithubStore();
   const { status, reposData, fetchReposData } = useLibraryStore();
   const { reposItemsPerPage } = usePaginationStore();
-  const { data } = useSession();
-  const email = data?.user?.email ?? "";
+  const { email } = useGetUser();
 
   const findMatchData = (name: string) =>
     reposData.find((repo) => repo.id === name);
@@ -49,6 +48,11 @@ export default function RepositoryList({ className }: { className?: string }) {
   return (
     <section className="flex w-full flex-col gap-6">
       <ReposToolbar setRepos={setRepos} repositories={repositories} />
+      {repos.length === 0 && (
+        <p className="w-full pt-20 text-center">
+          조건에 해당하는 데이터가 존재하지 않습니다.
+        </p>
+      )}
       <ul
         className={twMerge(
           "grid w-full grid-cols-4 gap-6",
@@ -63,9 +67,6 @@ export default function RepositoryList({ className }: { className?: string }) {
             </li>
           );
         })}
-        {repos.length === 0 && (
-          <p>조건에 해당하는 데이터가 존재하지 않습니다.</p>
-        )}
       </ul>
       <Pagination
         totalItems={repos.length}

--- a/src/app/repos/_components/UserItemWithLogout.tsx
+++ b/src/app/repos/_components/UserItemWithLogout.tsx
@@ -3,7 +3,7 @@
 import Button from "@/components/common/Button";
 import UserItem from "@/components/common/UserItem";
 import { useState } from "react";
-import LogoutComfirmModal from "./LogoutComfirmModal";
+import LogoutConfirmModal from "./LogoutConfirmModal";
 
 export default function UserItemWithLogout() {
   const [modalOpen, setModalOpen] = useState<boolean>(false);
@@ -11,7 +11,7 @@ export default function UserItemWithLogout() {
   return (
     <>
       {modalOpen && (
-        <LogoutComfirmModal isOpen={modalOpen} onClose={setModalOpen} />
+        <LogoutConfirmModal isOpen={modalOpen} onClose={setModalOpen} />
       )}
       <div className="flex items-center justify-between">
         <UserItem />

--- a/src/app/repos/_utils/fetchRepos.ts
+++ b/src/app/repos/_utils/fetchRepos.ts
@@ -5,10 +5,13 @@ export const getReposData = async (email: string) => {
   try {
     const reposCollectionRef = collection(db, `users/${email}/repos`);
     const querySnapshot = await getDocs(reposCollectionRef);
-    console.log(querySnapshot);
-    return querySnapshot;
+    const repos = querySnapshot.docs.map((doc) => ({
+      id: doc.id,
+      ...doc.data(),
+    }));
+    return repos;
   } catch (error) {
-    throw new Error("DB에서 Repos Data를 받아오는데 실패했습니다.");
+    throw new Error(`${error}, "DB에서 Repos Data를 받아오는데 실패했습니다."`);
   }
 };
 

--- a/src/app/repos/_utils/fetchRepos.ts
+++ b/src/app/repos/_utils/fetchRepos.ts
@@ -1,0 +1,22 @@
+import { db } from "@/lib/firebase";
+import { collection, doc, getDocs, setDoc } from "firebase/firestore";
+
+export const getReposData = async (email: string) => {
+  try {
+    const reposCollectionRef = collection(db, `users/${email}/repos`);
+    const querySnapshot = await getDocs(reposCollectionRef);
+    console.log(querySnapshot);
+    return querySnapshot;
+  } catch (error) {
+    throw new Error("DB에서 Repos Data를 받아오는데 실패했습니다.");
+  }
+};
+
+export const postRepo = async (email: string, repoName: string, data: any) => {
+  try {
+    const repoDocRef = doc(collection(db, `users/${email}/repos`), repoName);
+    await setDoc(repoDocRef, data, { merge: true });
+  } catch (error) {
+    throw new Error("DB에서 Repo Data를 업데이트 하는데 실패했습니다.");
+  }
+};

--- a/src/app/repos/_utils/filterRepos.ts
+++ b/src/app/repos/_utils/filterRepos.ts
@@ -1,9 +1,16 @@
 import { RepositoryProps } from "@/types";
+import { RepoItem } from "@/types/library";
+import { findMatchData } from "./findMatchData";
 
 export const filterRepos = (
-  name: "recent" | "bookmark",
+  type: "recent" | "bookmark",
   setRepos: React.Dispatch<React.SetStateAction<RepositoryProps[]>>,
   repositories: RepositoryProps[],
+  reposData: RepoItem[],
 ) => {
-  setRepos(() => repositories.filter((repo) => repo[name]));
+  const filteredRepositories = repositories.filter((repo) => {
+    const matchData = findMatchData(repo, reposData);
+    if (matchData && matchData[type]) return repo;
+  });
+  setRepos(() => filteredRepositories);
 };

--- a/src/app/repos/_utils/findMatchData.ts
+++ b/src/app/repos/_utils/findMatchData.ts
@@ -1,0 +1,8 @@
+import { RepositoryProps } from "@/types";
+import { RepoItem } from "@/types/library";
+
+export const findMatchData = (repo: RepositoryProps, reposData: RepoItem[]) => {
+  const matchData = reposData.find((repoData) => repoData.id === repo.name);
+
+  return matchData;
+};

--- a/src/components/common/Header.tsx
+++ b/src/components/common/Header.tsx
@@ -11,12 +11,13 @@ import {
   LightModeIcon,
 } from "../../../public/assets/svg/SvgIcons";
 import Link from "next/link";
-import { useSession } from "next-auth/react";
 import { signOut } from "next-auth/react";
+import { useGetUser } from "@/hooks/useGetUser";
+import { customSignOut } from "@/lib/customAuth";
 
 const Header: React.FC = () => {
   const { theme, setTheme } = useTheme();
-  const { data: session, status } = useSession();
+  const { session, status, email } = useGetUser();
   const [mounted, setMounted] = useState(false);
   const pathname = usePathname();
 
@@ -62,7 +63,11 @@ const Header: React.FC = () => {
           {status === "authenticated" && (
             <span
               className="cursor-pointer hover:text-accent-blue"
-              onClick={() => signOut({ callbackUrl: pathname })}
+              onClick={() => {
+                if (email) {
+                  customSignOut(email, "/");
+                }
+              }}
             >
               로그아웃
             </span>

--- a/src/components/common/UserItem.tsx
+++ b/src/components/common/UserItem.tsx
@@ -1,11 +1,10 @@
 "use client";
 
 import UserPic from "@/components/common/UserPic";
-import { useSession } from "next-auth/react";
+import { useGetUser } from "@/hooks/useGetUser";
 
 export default function UserItem() {
-  const { data, status } = useSession();
-  const { user } = data ?? {};
+  const { status, user, name, image, email } = useGetUser();
 
   if (status === "loading") {
     return <p>loading...</p>;
@@ -14,12 +13,12 @@ export default function UserItem() {
   return (
     <>
       {!user && <p>유저 데이터를 찾을 수 없습니다.</p>}
-      {user && user.name && (
+      {name && (
         <div className="flex items-center gap-11">
-          <UserPic image={user?.image ?? ""} name={user.name} />
-          <p className="flex flex-col text-[40px] font-medium leading-[1.2] tracking-tighter text-text-gray-dark dark:text-custom-dark-text">
+          <UserPic image={image ?? ""} name={name} />
+          <p className="text-text-gray-dark flex flex-col text-[40px] font-medium leading-[1.2] tracking-tighter dark:text-custom-dark-text">
             <span>Hello,</span>
-            <span>{user?.email}</span>
+            <span>{email}</span>
           </p>
         </div>
       )}

--- a/src/hooks/fetchData.ts
+++ b/src/hooks/fetchData.ts
@@ -74,6 +74,19 @@ export const deleteData = async (url: string, id: string) => {
   }
 };
 
+export const deleteCollection = async (url: string) => {
+  try {
+    const docsRef = collection(db, url);
+    const docsSnapshot = await getDocs(docsRef);
+    docsSnapshot.forEach(async (docSnap) => {
+      await deleteDoc(doc(db, url, docSnap.id));
+    });
+    return "Entire collection files deleted successfully.";
+  } catch (error) {
+    throw new Error(`Failed to delete collection: ${url}`);
+  }
+};
+
 //검색어 보내기
 export const postSearch = async (url: string, data: string) => {
   try {

--- a/src/hooks/useFilterItems.ts
+++ b/src/hooks/useFilterItems.ts
@@ -57,9 +57,6 @@ export const useFilterReposType = (
     libraryState.bookmark,
     libraryState.recent,
     setRepos,
-    FILTER_TYPE.repoInteraction,
-    FILTER_TYPE.repoType,
-    libraryState,
   ]);
 };
 

--- a/src/hooks/useFilterItems.ts
+++ b/src/hooks/useFilterItems.ts
@@ -4,30 +4,47 @@ import { useEffect } from "react";
 import { TDropdownSelect } from "../app/repos/_components/LibraryToolbar";
 import { TClippingArticle } from "@/app/me/(me-layout)/scraps/_components/ClippingArticle";
 import { useLibraryStore } from "@/store/useLibraryStore";
+import { findMatchData } from "@/app/repos/_utils/findMatchData";
 
-export const useFilterRepos = (
+export const useFilterReposType = (
   selectedItem: TDropdownSelect,
   setRepos: React.Dispatch<React.SetStateAction<RepositoryProps[]>>,
   repositories: RepositoryProps[],
 ) => {
-  const { libraryState } = useLibraryStore();
+  const { libraryState, reposData } = useLibraryStore();
+
+  const FILTER_TYPE = {
+    repoInteraction: {
+      bookmark: (repo: RepositoryProps) =>
+        findMatchData(repo, reposData)?.bookmark,
+      recent: (repo: RepositoryProps) => findMatchData(repo, reposData)?.recent,
+    },
+    repoType: {
+      검사완료: (repo: RepositoryProps) =>
+        findMatchData(repo, reposData)?.status === "COMPLETED",
+      검사중: (repo: RepositoryProps) =>
+        findMatchData(repo, reposData)?.status === "IN_PROGRESS",
+    },
+  };
+
+  type repoInteractionKeys = keyof typeof FILTER_TYPE.repoInteraction;
+  type repoTypeKeys = keyof typeof FILTER_TYPE.repoType;
+  type libraryStateKeys = keyof typeof libraryState;
 
   useEffect(() => {
     let filteredRepos = repositories;
 
-    if (libraryState.bookmark) {
-      filteredRepos = repositories.filter((repo) => repo.bookmark);
-    } else if (libraryState.recent) {
-      filteredRepos = repositories.filter((repo) => repo.recent);
-    }
+    Object.keys(FILTER_TYPE.repoInteraction).forEach((key) => {
+      if (libraryState[key as libraryStateKeys]) {
+        filteredRepos = filteredRepos.filter(
+          FILTER_TYPE.repoInteraction[key as repoInteractionKeys],
+        );
+      }
+    });
 
-    if (selectedItem.type === "검사완료") {
+    if (selectedItem.type in FILTER_TYPE.repoType) {
       filteredRepos = filteredRepos.filter(
-        (repo) => repo.status === "COMPLETED",
-      );
-    } else if (selectedItem.type === "검사중") {
-      filteredRepos = filteredRepos.filter(
-        (repo) => repo.status === "IN_PROGRESS",
+        FILTER_TYPE.repoType[selectedItem.type as repoTypeKeys],
       );
     }
 

--- a/src/hooks/useFilterItems.ts
+++ b/src/hooks/useFilterItems.ts
@@ -57,6 +57,9 @@ export const useFilterReposType = (
     libraryState.bookmark,
     libraryState.recent,
     setRepos,
+    FILTER_TYPE.repoInteraction,
+    FILTER_TYPE.repoType,
+    libraryState,
   ]);
 };
 

--- a/src/hooks/useGetUser.ts
+++ b/src/hooks/useGetUser.ts
@@ -1,0 +1,9 @@
+import { useSession } from "next-auth/react";
+
+export const useGetUser = () => {
+  const { data, status } = useSession();
+  const { user } = data ?? {};
+  const { email, image, name } = user ?? {};
+
+  return { session: data, status, user, email, image, name };
+};

--- a/src/lib/customAuth.ts
+++ b/src/lib/customAuth.ts
@@ -1,18 +1,13 @@
 import { signOut } from "next-auth/react";
-import { deleteData } from "@/hooks/fetchData";
+import { deleteCollection, deleteData } from "@/hooks/fetchData";
 
 export const customSignOut = async (email: string, callbackUrl?: string) => {
   try {
     if (email) {
-      Promise.resolve().then(() => {
-        deleteData('users', email)
-          .then(() => {
-            console.log('User data deleted successfully');
-          })
-          .catch(error => {
-            console.error("Failed to delete user data:", error);
-          });
-      });
+      await deleteCollection(`users/${email}/repos`);
+      await deleteData("users", email);
+
+      console.log("User data deleted successfully");
     }
     await signOut({ callbackUrl });
   } catch (error) {

--- a/src/store/useGithubStore.ts
+++ b/src/store/useGithubStore.ts
@@ -1,105 +1,81 @@
 import { create } from "zustand";
 import { RepositoryState } from "@/types";
-import { persist } from "zustand/middleware";
 
-export const useGithubStore = create(
-  persist<RepositoryState>(
-    (set, get) => ({
-      repositories: [],
-      currentRepo: null,
-      currentPath: "",
-      repoContents: [],
-      selectedFile: null,
-      selectedFiles: [],
-      isLoading: false,
-      error: null,
+export const useGithubStore = create<RepositoryState>((set, get) => ({
+  repositories: [],
+  currentRepo: null,
+  currentPath: "",
+  repoContents: [],
+  selectedFile: null,
+  selectedFiles: [],
+  isLoading: false,
+  error: null,
 
-      fetchRepositories: async () => {
-        set({ isLoading: true, error: null });
-        try {
-          const response = await fetch("/api/github/repositories");
-          if (!response.ok) throw new Error("Failed to fetch repositories");
-          const data = await response.json();
-          set({ repositories: data, isLoading: false });
-        } catch (error) {
-          set({ error: (error as Error).message, isLoading: false });
-        }
-      },
+  fetchRepositories: async () => {
+    set({ isLoading: true, error: null });
+    try {
+      const response = await fetch("/api/github/repositories");
+      if (!response.ok) throw new Error("Failed to fetch repositories");
+      const data = await response.json();
+      set({ repositories: data, isLoading: false });
+    } catch (error) {
+      set({ error: (error as Error).message, isLoading: false });
+    }
+  },
 
-      fetchRepoContents: async (
-        owner: string,
-        repo: string,
-        path: string = "",
-      ) => {
-        set({ repoContents: [], isLoading: true, error: null });
-        try {
-          const response = await fetch(
-            `/api/github/contents?owner=${owner}&repo=${repo}&path=${path}`,
-          );
-          if (!response.ok)
-            throw new Error("Failed to fetch repository contents");
-          const data = await response.json();
-          set({
-            currentRepo: `${owner}/${repo}`,
-            currentPath: path,
-            repoContents: data,
-            isLoading: false,
-          });
-        } catch (error) {
-          set({ error: (error as Error).message, isLoading: false });
-        }
-      },
+  fetchRepoContents: async (owner: string, repo: string, path: string = "") => {
+    set({ repoContents: [], isLoading: true, error: null });
+    try {
+      const response = await fetch(
+        `/api/github/contents?owner=${owner}&repo=${repo}&path=${path}`,
+      );
+      if (!response.ok) throw new Error("Failed to fetch repository contents");
+      const data = await response.json();
+      set({
+        currentRepo: `${owner}/${repo}`,
+        currentPath: path,
+        repoContents: data,
+        isLoading: false,
+      });
+    } catch (error) {
+      set({ error: (error as Error).message, isLoading: false });
+    }
+  },
 
-      selectFile: async (owner: string, repo: string, path: string) => {
-        set({ isLoading: true, error: null });
-        try {
-          const response = await fetch(
-            `/api/github/file?owner=${owner}&repo=${repo}&path=${path}`,
-          );
-          if (!response.ok) throw new Error("Failed to fetch file content");
-          const data = await response.json();
+  selectFile: async (owner: string, repo: string, path: string) => {
+    set({ isLoading: true, error: null });
+    try {
+      const response = await fetch(
+        `/api/github/file?owner=${owner}&repo=${repo}&path=${path}`,
+      );
+      if (!response.ok) throw new Error("Failed to fetch file content");
+      const data = await response.json();
 
-          const decodedContent = decodeURIComponent(escape(atob(data.content)));
-          
-          set({
-            selectedFile: { ...data, content: decodedContent },
-            isLoading: false
-          });
-        } catch (error) {
-          set({ error: (error as Error).message, isLoading: false });
-        }
-      },
+      const decodedContent = decodeURIComponent(escape(atob(data.content)));
 
-      toggleSelectFile: (filePath: string) => {
-        set((state) => {
-          const selectedFiles = state.selectedFiles.includes(filePath)
-            ? state.selectedFiles.filter((path) => path !== filePath)
-            : [...state.selectedFiles, filePath];
-          return { selectedFiles };
-        });
-      },
+      set({
+        selectedFile: { ...data, content: decodedContent },
+        isLoading: false,
+      });
+    } catch (error) {
+      set({ error: (error as Error).message, isLoading: false });
+    }
+  },
 
-      clearSelectedFiles: () => {
-        set({ selectedFiles: [] });
-      },
+  toggleSelectFile: (filePath: string) => {
+    set((state) => {
+      const selectedFiles = state.selectedFiles.includes(filePath)
+        ? state.selectedFiles.filter((path) => path !== filePath)
+        : [...state.selectedFiles, filePath];
+      return { selectedFiles };
+    });
+  },
 
-      clearSelection: () => {
-        set({ selectedFile: null });
-      },
+  clearSelectedFiles: () => {
+    set({ selectedFiles: [] });
+  },
 
-      setRepositories: (id, bookmark) =>
-        set((state) => {
-          const updatedRepositories = state.repositories.map((repo) => {
-            if (repo.id === id) {
-              return { ...repo, bookmark: bookmark };
-            }
-            return repo;
-          });
-          return { repositories: updatedRepositories };
-        }),
-    }),
-    {
-      name: "githubStorage",
-    },
-  ),
-);
+  clearSelection: () => {
+    set({ selectedFile: null });
+  },
+}));

--- a/src/store/useLibraryStore.ts
+++ b/src/store/useLibraryStore.ts
@@ -1,10 +1,28 @@
+import { getReposData } from "@/app/repos/_utils/fetchRepos";
 import { LibraryState } from "@/types/library";
 import { create } from "zustand";
 
-export const useLibraryStore = create<LibraryState>((set) => ({
+export const useLibraryStore = create<LibraryState>((set, get) => ({
+  status: { isLoading: false, error: null },
   libraryState: { recent: false, bookmark: false },
+  reposData: [],
   setLibraryState: (newLibraryState) =>
-    set(() => {
-      return { libraryState: { ...newLibraryState } };
+    set((state) => {
+      return { libraryState: { ...state, ...newLibraryState } };
     }),
+  fetchReposData: async (email) => {
+    set({
+      status: { isLoading: true, error: null },
+    });
+    try {
+      const repos = await getReposData(email);
+      console.log("store: ", repos);
+      set({ reposData: repos, status: { isLoading: false, error: null } });
+    } catch (error) {
+      set({
+        status: { isLoading: false, error: (error as Error).message },
+      });
+    }
+  },
+  setReposData: (data) => set({ reposData: data }),
 }));

--- a/src/types/github-repos.d.ts
+++ b/src/types/github-repos.d.ts
@@ -11,9 +11,6 @@ export type RepositoryProps = {
   description: string | null;
   created_at: string;
   /* 추후 필요한 필드 추가 */
-  status?: RepositoryStatus;
-  bookmark?: boolean;
-  recent?: boolean;
 };
 
 export type RepositoryContent = {
@@ -52,7 +49,7 @@ export type RepositoryState = {
     repo: string,
     path?: string,
   ) => Promise<void>;
-  
+
   selectFile: (owner: string, repo: string, path: string) => Promise<void>;
   toggleSelectFile: (filePath: string) => void;
   clearSelection: () => void;

--- a/src/types/github-repos.d.ts
+++ b/src/types/github-repos.d.ts
@@ -54,7 +54,6 @@ export type RepositoryState = {
   toggleSelectFile: (filePath: string) => void;
   clearSelection: () => void;
   clearSelectedFiles: () => void;
-  setRepositories: (id: number, bookmark: boolean) => void;
 };
 
 export type TAnalyzeModalProp = {

--- a/src/types/library.d.ts
+++ b/src/types/library.d.ts
@@ -1,4 +1,25 @@
+import { RepositoryStatus } from ".";
+
+export type RepoItem = {
+  recent?: boolean;
+  bookmark?: boolean;
+  id: string;
+  status?: RepositoryStatus;
+};
+
+export type FilterType = {
+  recent: boolean;
+  bookmark: boolean;
+};
+
 export type LibraryState = {
-  libraryState: { recent: boolean; bookmark: boolean };
+  status: {
+    isLoading: boolean;
+    error: string | null;
+  };
+  libraryState: FilterType;
+  reposData: repoItem[];
   setLibraryState: ({ recent: boolean, bookmark: boolean }) => void;
+  fetchReposData: (email: string) => void;
+  setReposData: (data: reposData) => void;
 };


### PR DESCRIPTION
## Description
- `db` 구조가 `users/{userEmail}/repos/{repoName}` 형태로 이루어질 수 있도록 `fetchRepos` 유틸 함수 파일을 생성했습니다. 해당 파일은 `db`에서 `repos` 컬렉션 데이터를 가져오는 `getReposData`와 `repos` 내부 아이템 필드를 추가/변경시에 사용할 수 있는 `postRepo` 함수를 포함합니다. (기존 데이터가 존재할 경우 `update`, 존재하지 않을 경우 `set`과 같이 동작합니다.) 
- `db`의 `repos` 데이터와 비교하여 북마크, 검사 결과 칩, 최근 본 레포지토리 등을 확인할 수 있도록 `RepositoryList`, `RepositoryItem`, `ReposFilterButton` 등 내부 컴포넌트를 수정하였습니다. 
- 북마크 버튼 클릭시 `debounce`가 제대로 적용될 수 있도록 로직 수정 및 적용하였습니다. `debounce`는 공통으로 사용할 수 있도록 `utils`에 빼두었으니 필요하신 분은 사용하세요!
- 레포지토리 아이템 `filter` 로직을 변경된 데이터에 맞게 사용할 수 있도록 수정했습니다. 
- `useGetUser` 커스텀 훅을 생성하여 `session`, `status`, `user`, `email`, `name`, `image` 등 세션 데이터 출력을 간소화할 수 있도록 했습니다. 일단 보이는 컴포넌트에서는 수정해두었는데 필요하신 분들은 가져다 쓰시면 됩니다!
- `fetchData` 함수 모음에 `deleteCollection`을 추가했습니다. 유저 데이터 삭제시 해당 유저 `id` 내부의 `collection`을 별도 삭제하는 로직이 필요해서 생성하였으며 다른 컬렉션 데이터도 삭제할 수 있도록 범용적으로 생성해두었으니 필요한 경우 사용해주세요! 컬렉션 경로만 `param`으로 전달하시면 됩니다. (컬렉션 내부의 모든 `doc`을 삭제합니다) 
- `customAuth`의 `customSignOut` 함수에 `repos` 컬렉션을 삭제하는 로직을 추가하고, `Promise/then` 형태의 로직을 `async/await`으로 수정하였습니다. 
- `githubStore`에서 더이상 사용하지 않는 `setRepositories` 메서드를 삭제하고 `persist` 미들웨어도 함께 제거하였습니다. 

## Changes Made
- `fetchRepos`, `deleteCollection` 유틸 함수 추가 
- `bookmark` 클릭시 `debounce` 적용
- `useFilterItem` 훅 내부 로직 수정 
- `useGetUser` 커스텀 훅 생성 
- `customSignOut` 내부 로직 추가, 수정 
- `LogoutComfirmModal` -> `LogoutConfirmModal` 리네이밍 
- `signOut`이 사용되는 부분을 `customSignOut`으로 변경
- `useSession`이 사용되는 부분을 `useGetUser`로 변경
- `githubStore` 내부 `setRepositories` 삭제, `persist` 미들웨어 제거 

## Screenshots
![image](https://github.com/user-attachments/assets/e48aad27-b47e-434d-81e0-827203c2b166)

## IssueNumber

#70 