### PR TITLE
[#112] contact validation/modal 

### DIFF
--- a/src/app/(home)/_components/Inquiry.tsx
+++ b/src/app/(home)/_components/Inquiry.tsx
@@ -1,41 +1,6 @@
-"use client";
-
-import { useEffect } from "react";
-
-import Input from "@/components/common/Input";
-import Textarea from "@/components/common/Textarea";
-import Button from "@/components/common/Button";
-
-import { InquiryForm } from "@/types";
-import { useInquiryStore } from "@/store/useInquiryStore";
-import { useSession } from "next-auth/react";
+import ContactForm from "@/components/common/ContactForm";
 
 export default function Inquiry() {
-  const { formData, isSubmitting, setFormData, submitForm } = useInquiryStore();
-  const { data: session, status } = useSession();
-
-  useEffect(() => {
-    if (status === "authenticated" && session?.user) {
-      setFormData("name", session.user.name || "");
-      setFormData("email", session.user.email || "");
-    } else if (status === "unauthenticated") {
-      setFormData("name", "");
-      setFormData("email", "");
-    }
-  }, [status, session, setFormData]);
-
-  const handleChange = (
-    e: React.ChangeEvent<HTMLInputElement | HTMLTextAreaElement>,
-  ) => {
-    const { name, value } = e.target;
-    setFormData(name as keyof InquiryForm, value);
-  };
-
-  const handleSubmit = (e: React.FormEvent<HTMLFormElement>) => {
-    e.preventDefault();
-    submitForm();
-  };
-
   return (
     <section className="flex min-h-[800px] w-full flex-col justify-between gap-x-10 gap-y-10 px-6 pb-[80px] pt-[100px] sm:px-8 md:px-[60px] lg:flex-row lg:gap-x-16 lg:gap-y-0 lg:px-[80px] xl:px-[90px] 2xl:px-[190px]">
       <div className="flex flex-shrink-0 flex-col text-center tracking-[-0.01em] md:flex-grow lg:text-left">
@@ -65,89 +30,7 @@ export default function Inquiry() {
           </div>
         </div>
       </div>
-
-      <div className="w-full rounded-[40px] border-[1.5px] border-primary-purple-500 px-5 py-8 dark:border-transparent dark:bg-zinc-700 md:p-8 lg:max-w-[800px] lg:p-10 xl:max-w-[800px] xl:p-[40px] 2xl:max-w-[900px] 2xl:p-[60px]">
-        <div className="rounded-3xl text-center leading-[1.5] tracking-[-0.01em] lg:text-left">
-          <h3 className="mb-4 text-xl font-bold md:text-[22px] lg:mb-[32px] lg:text-[24px]">
-            문의하기
-          </h3>
-          <p className="mb-6 text-sm font-normal text-[#8f8f8f] dark:text-gray-300 md:text-[15px] lg:mb-[32px] lg:text-[16px]">
-            문의하고싶은 내용을 구체적으로 작성해주셔야{" "}
-            <span className="inline lg:hidden">
-              <br />
-            </span>
-            피드백이 정상적으로 반영됩니다.
-          </p>
-          <form
-            onSubmit={handleSubmit}
-            className="space-y-3 text-left md:space-y-4 lg:space-y-[32px]"
-          >
-            <div>
-              <label
-                htmlFor="name"
-                className="mb-2 block text-sm font-medium md:text-[18px]"
-              >
-                Name
-              </label>
-              <Input
-                type="text"
-                id="name"
-                name="name"
-                value={formData.name}
-                onChange={handleChange}
-                className="placeholder:text-sm dark:placeholder:text-gray-400 md:placeholder:text-base"
-                placeholder="이름을 적어주세요."
-              />
-            </div>
-
-            <div>
-              <label
-                htmlFor="email"
-                className="mb-2 block text-sm font-medium md:text-[18px]"
-              >
-                Email
-              </label>
-              <Input
-                type="email"
-                id="email"
-                name="email"
-                value={formData.email}
-                onChange={handleChange}
-                className="placeholder:text-sm dark:placeholder:text-gray-400 md:placeholder:text-base"
-                placeholder="justin@flawfactory.kr"
-                disabled={status === "authenticated"}
-                readOnly={status === "authenticated"}
-              />
-            </div>
-
-            <div>
-              <label
-                htmlFor="message"
-                className="mb-2 block text-sm font-medium md:text-[18px]"
-              >
-                Message
-              </label>
-              <Textarea
-                id="message"
-                name="message"
-                value={formData.message}
-                onChange={handleChange}
-                placeholder="내용을 적어주세요."
-                className="h-40 placeholder:text-sm dark:placeholder:text-gray-400 md:h-48 md:placeholder:text-base lg:h-52"
-              />
-            </div>
-
-            <Button
-              type="submit"
-              theme="filled"
-              size="large"
-              disabled={isSubmitting}
-            >
-              {isSubmitting ? "전송 중..." : "문의 보내기"}
-            </Button>
-          </form>
-        </div>
-      </div>
+      <ContactForm />
     </section>
   );
 }

--- a/src/app/(home)/_components/Inquiry.tsx
+++ b/src/app/(home)/_components/Inquiry.tsx
@@ -1,4 +1,4 @@
-import ContactForm from "@/components/common/ContactForm";
+import ContactForm from "@/components/common/contact/ContactForm";
 
 export default function Inquiry() {
   return (

--- a/src/components/common/ContactForm.tsx
+++ b/src/components/common/ContactForm.tsx
@@ -1,0 +1,134 @@
+"use client";
+
+import { useInquiryStore } from "@/store/useInquiryStore";
+import Button from "./Button";
+import Input from "./Input";
+import Textarea from "./Textarea";
+import { useSession } from "next-auth/react";
+import { useEffect } from "react";
+import { InquiryForm } from "@/types";
+import { validateForm } from "@/utils/validateForm";
+
+export default function ContactForm() {
+  const { formData, isSubmitting, setFormData, submitForm } = useInquiryStore();
+  const { data: session, status } = useSession();
+
+  useEffect(() => {
+    if (status === "authenticated" && session?.user) {
+      setFormData("name", session.user.name || "");
+      setFormData("email", session.user.email || "");
+    } else if (status === "unauthenticated") {
+      setFormData("name", "");
+      setFormData("email", "");
+    }
+  }, [status, session, setFormData]);
+
+  const handleChange = (
+    e: React.ChangeEvent<HTMLInputElement | HTMLTextAreaElement>,
+  ) => {
+    const { name, value } = e.target;
+    setFormData(name as keyof InquiryForm, value);
+    e.target.setCustomValidity("");
+    e.target.reportValidity();
+  };
+
+  const handleSubmit = async (e: React.FormEvent<HTMLFormElement>) => {
+    e.preventDefault();
+
+    const isFormValid = validateForm(e);
+
+    if (!isFormValid) return;
+
+    await submitForm();
+
+    if (status === "unauthenticated") {
+      setFormData("name", "");
+      setFormData("email", "");
+    }
+  };
+
+  return (
+    <div className="w-full rounded-[40px] border-[1.5px] border-primary-purple-500 px-5 py-8 dark:border-transparent dark:bg-zinc-700 md:p-8 lg:max-w-[800px] lg:p-10 xl:max-w-[800px] xl:p-[40px] 2xl:max-w-[900px] 2xl:p-[60px]">
+      <div className="rounded-3xl text-center leading-[1.5] tracking-[-0.01em] lg:text-left">
+        <h3 className="mb-4 text-xl font-bold md:text-[22px] lg:mb-[32px] lg:text-[24px]">
+          문의하기
+        </h3>
+        <p className="mb-6 text-sm font-normal text-[#8f8f8f] dark:text-gray-300 md:text-[15px] lg:mb-[32px] lg:text-[16px]">
+          문의하고싶은 내용을 구체적으로 작성해주셔야{" "}
+          <span className="inline lg:hidden">
+            <br />
+          </span>
+          피드백이 정상적으로 반영됩니다.
+        </p>
+        <form
+          onSubmit={handleSubmit}
+          className="space-y-3 text-left md:space-y-4 lg:space-y-[32px]"
+        >
+          <div>
+            <label
+              htmlFor="name"
+              className="mb-2 block text-sm font-medium md:text-[18px]"
+            >
+              Name
+            </label>
+            <Input
+              type="text"
+              id="name"
+              name="name"
+              value={formData.name}
+              onChange={handleChange}
+              className="placeholder:text-sm dark:placeholder:text-gray-400 md:placeholder:text-base"
+              placeholder="이름을 적어주세요."
+            />
+          </div>
+
+          <div>
+            <label
+              htmlFor="email"
+              className="mb-2 block text-sm font-medium md:text-[18px]"
+            >
+              Email
+            </label>
+            <Input
+              type="email"
+              id="email"
+              name="email"
+              value={formData.email}
+              onChange={handleChange}
+              className="placeholder:text-sm dark:placeholder:text-gray-400 md:placeholder:text-base"
+              placeholder="justin@flawfactory.kr"
+              disabled={status === "authenticated"}
+              readOnly={status === "authenticated"}
+            />
+          </div>
+
+          <div>
+            <label
+              htmlFor="message"
+              className="mb-2 block text-sm font-medium md:text-[18px]"
+            >
+              Message
+            </label>
+            <Textarea
+              id="message"
+              name="message"
+              value={formData.message}
+              onChange={handleChange}
+              placeholder="내용을 적어주세요."
+              className="h-40 placeholder:text-sm dark:placeholder:text-gray-400 md:h-48 md:placeholder:text-base lg:h-52"
+            />
+          </div>
+
+          <Button
+            type="submit"
+            theme="filled"
+            size="large"
+            disabled={isSubmitting}
+          >
+            {isSubmitting ? "전송 중..." : "문의 보내기"}
+          </Button>
+        </form>
+      </div>
+    </div>
+  );
+}

--- a/src/components/common/Modal.tsx
+++ b/src/components/common/Modal.tsx
@@ -80,17 +80,39 @@ export default function Modal({
   );
 }
 
-function Title({ children }: { children: React.ReactNode }) {
+function Title({
+  children,
+  className,
+}: {
+  children: React.ReactNode;
+  className?: string;
+}) {
   return (
-    <h3 className="flex justify-center p-[10px] text-2xl font-semibold text-custom-light-text dark:text-custom-dark-text">
+    <h3
+      className={twMerge(
+        "flex justify-center p-[10px] text-2xl font-semibold text-custom-light-text dark:text-custom-dark-text",
+        className && className,
+      )}
+    >
       {children}
     </h3>
   );
 }
 
-function Description({ children }: { children: React.ReactNode }) {
+function Description({
+  children,
+  className,
+}: {
+  children: React.ReactNode;
+  className?: string;
+}) {
   return (
-    <div className="flex flex-col items-center justify-center gap-[20px] p-[10px] text-text-gray-default">
+    <div
+      className={twMerge(
+        "flex flex-col items-center justify-center gap-[20px] p-[10px] text-text-gray-default",
+        className && className,
+      )}
+    >
       {children}
     </div>
   );

--- a/src/components/common/contact/ContactForm.tsx
+++ b/src/components/common/contact/ContactForm.tsx
@@ -5,11 +5,13 @@ import Button from "../Button";
 import Input from "../Input";
 import Textarea from "../Textarea";
 import { useSession } from "next-auth/react";
-import { useEffect } from "react";
+import { useEffect, useState } from "react";
 import { InquiryForm } from "@/types";
 import { validateForm } from "@/utils/validateForm";
+import SubmitContactFormModal from "./SubmitContactFormModal";
 
 export default function ContactForm() {
+  const [modalOpen, setModalOpen] = useState<boolean>(false);
   const { formData, isSubmitting, setFormData, submitForm } = useInquiryStore();
   const { data: session, status } = useSession();
 
@@ -40,6 +42,7 @@ export default function ContactForm() {
     if (!isFormValid) return;
 
     await submitForm();
+    setModalOpen(true);
 
     if (status === "unauthenticated") {
       setFormData("name", "");
@@ -60,6 +63,9 @@ export default function ContactForm() {
           </span>
           피드백이 정상적으로 반영됩니다.
         </p>
+        {modalOpen && (
+          <SubmitContactFormModal isOpen={modalOpen} onClose={setModalOpen} />
+        )}
         <form
           onSubmit={handleSubmit}
           className="space-y-3 text-left md:space-y-4 lg:space-y-[32px]"

--- a/src/components/common/contact/ContactForm.tsx
+++ b/src/components/common/contact/ContactForm.tsx
@@ -12,7 +12,8 @@ import SubmitContactFormModal from "./SubmitContactFormModal";
 
 export default function ContactForm() {
   const [modalOpen, setModalOpen] = useState<boolean>(false);
-  const { formData, isSubmitting, setFormData, submitForm } = useInquiryStore();
+  const { formData, isSubmitting, error, setFormData, submitForm } =
+    useInquiryStore();
   const { data: session, status } = useSession();
 
   useEffect(() => {
@@ -42,6 +43,12 @@ export default function ContactForm() {
     if (!isFormValid) return;
 
     await submitForm();
+
+    if (error) {
+      alert(error);
+      return;
+    }
+
     setModalOpen(true);
 
     if (status === "unauthenticated") {

--- a/src/components/common/contact/ContactForm.tsx
+++ b/src/components/common/contact/ContactForm.tsx
@@ -1,9 +1,9 @@
 "use client";
 
 import { useInquiryStore } from "@/store/useInquiryStore";
-import Button from "./Button";
-import Input from "./Input";
-import Textarea from "./Textarea";
+import Button from "../Button";
+import Input from "../Input";
+import Textarea from "../Textarea";
 import { useSession } from "next-auth/react";
 import { useEffect } from "react";
 import { InquiryForm } from "@/types";

--- a/src/components/common/contact/SubmitContactFormModal.tsx
+++ b/src/components/common/contact/SubmitContactFormModal.tsx
@@ -1,0 +1,38 @@
+import Button from "../Button";
+import Modal from "../Modal";
+
+export default function SubmitContactFormModal({
+  isOpen,
+  onClose,
+}: {
+  isOpen: boolean;
+  onClose: React.Dispatch<React.SetStateAction<boolean>>;
+}) {
+  return (
+    <Modal
+      isOpen={isOpen}
+      onClose={() => onClose(false)}
+      dimmed
+      className="mx-6 gap-4 p-[60px] sm:gap-6"
+    >
+      <Modal.Box>
+        <Modal.Title className="font-bold">문의를 보냈어요!</Modal.Title>
+        <Modal.Desc>
+          <p className="flex flex-col sm:flex-row sm:gap-1">
+            <span>문의를 성공적으로 전송했어요.</span>
+            <span>빠른 시일내에 답변해드릴게요.</span>
+          </p>
+        </Modal.Desc>
+      </Modal.Box>
+      <Modal.Button className="mt-[18px]">
+        <Button
+          theme="filled"
+          onClick={() => onClose(false)}
+          className="w-[335px] text-base font-semibold hover:shadow-none sm:text-lg md:text-lg xl:text-lg"
+        >
+          닫기
+        </Button>
+      </Modal.Button>
+    </Modal>
+  );
+}

--- a/src/store/useInquiryStore.ts
+++ b/src/store/useInquiryStore.ts
@@ -10,6 +10,7 @@ const iFormData: InquiryForm = {
 export const useInquiryStore = create<InquiryState>((set, get) => ({
   formData: iFormData,
   isSubmitting: false,
+  error: null,
   setFormData: (field, value) =>
     set((state) => ({
       formData: { ...state.formData, [field]: value },
@@ -30,13 +31,14 @@ export const useInquiryStore = create<InquiryState>((set, get) => ({
       });
 
       if (!response.ok) {
+        set({ error: `문의 전송에 실패했습니다.` });
         throw new Error("Failed to send email");
       }
 
       const data = await response.json();
       set((state) => ({ formData: { ...state.formData, message: "" } }));
     } catch (error) {
-      alert(error instanceof Error ? error.message : "Error");
+      set({ error: `문의 전송에 실패했습니다. ${(error as Error)?.message}` });
     } finally {
       setIsSubmitting(false);
     }

--- a/src/store/useInquiryStore.ts
+++ b/src/store/useInquiryStore.ts
@@ -34,7 +34,6 @@ export const useInquiryStore = create<InquiryState>((set, get) => ({
       }
 
       const data = await response.json();
-      alert(data.message);
       set((state) => ({ formData: { ...state.formData, message: "" } }));
     } catch (error) {
       alert(error instanceof Error ? error.message : "Error");

--- a/src/store/useInquiryStore.ts
+++ b/src/store/useInquiryStore.ts
@@ -1,42 +1,43 @@
-import { create } from 'zustand';
-import { InquiryForm, InquiryState } from '@/types/inquiry';
+import { create } from "zustand";
+import { InquiryForm, InquiryState } from "@/types/inquiry";
 
 const iFormData: InquiryForm = {
-  name: '',
-  email: '',
-  message: ''
+  name: "",
+  email: "",
+  message: "",
 };
 
 export const useInquiryStore = create<InquiryState>((set, get) => ({
   formData: iFormData,
   isSubmitting: false,
-  setFormData: (field, value) => set((state) => ({
-    formData: { ...state.formData, [field]: value }
-  })),
+  setFormData: (field, value) =>
+    set((state) => ({
+      formData: { ...state.formData, [field]: value },
+    })),
   setIsSubmitting: (isSubmitting) => set({ isSubmitting }),
   submitForm: async () => {
     const { formData, setIsSubmitting } = get();
 
     setIsSubmitting(true);
-    
+
     try {
-      const response = await fetch('/api/contact', {
-        method: 'POST',
+      const response = await fetch("/api/contact", {
+        method: "POST",
         headers: {
-          'Content-Type': 'application/json',
+          "Content-Type": "application/json",
         },
         body: JSON.stringify(formData),
       });
 
       if (!response.ok) {
-        throw new Error('Failed to send email');
+        throw new Error("Failed to send email");
       }
 
       const data = await response.json();
       alert(data.message);
-      set({ formData: iFormData }); 
+      set((state) => ({ formData: { ...state.formData, message: "" } }));
     } catch (error) {
-      alert(error instanceof Error ? error.message : 'Error');
+      alert(error instanceof Error ? error.message : "Error");
     } finally {
       setIsSubmitting(false);
     }

--- a/src/types/inquiry.d.ts
+++ b/src/types/inquiry.d.ts
@@ -1,8 +1,14 @@
+export type ValidationRule = {
+  required: boolean;
+  errorMessage: string;
+  pattern?: RegExp;
+};
+
 export type InquiryForm = {
   name: string;
   email: string;
   message: string;
-}
+};
 
 export type InquiryState = {
   formData: InquiryForm;

--- a/src/types/inquiry.d.ts
+++ b/src/types/inquiry.d.ts
@@ -12,6 +12,7 @@ export type InquiryForm = {
 
 export type InquiryState = {
   formData: InquiryForm;
+  error: null | string;
   isSubmitting: boolean;
   setFormData: (field: keyof InquiryForm, value: string) => void;
   setIsSubmitting: (isSubmitting: boolean) => void;

--- a/src/utils/validateForm.ts
+++ b/src/utils/validateForm.ts
@@ -1,0 +1,45 @@
+import { InquiryForm, ValidationRule } from "@/types";
+
+const CONTACT_VALIDATION_RULES: Record<keyof InquiryForm, ValidationRule> = {
+  name: {
+    required: true,
+    errorMessage: "이름을 입력해주세요.",
+  },
+  email: {
+    required: true,
+    pattern: /^[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,}$/,
+    errorMessage: "올바른 이메일 주소를 입력해주세요.",
+  },
+  message: {
+    required: true,
+    errorMessage: "문의 내용을 입력해주세요.",
+  },
+};
+
+export const validateForm = (e: React.FormEvent) => {
+  let isValid = true;
+
+  for (const field in CONTACT_VALIDATION_RULES) {
+    const inputEl = document.querySelector(`[name="${field}"]`) as
+      | HTMLInputElement
+      | HTMLTextAreaElement;
+    const rules = CONTACT_VALIDATION_RULES[field as keyof InquiryForm];
+
+    if (!inputEl) return;
+
+    if (rules.required && inputEl.value.trim() === "") {
+      inputEl.setCustomValidity(rules.errorMessage);
+      inputEl.reportValidity();
+      isValid = false;
+    } else if (rules.pattern && !rules.pattern.test(inputEl.value)) {
+      inputEl.setCustomValidity(rules.errorMessage);
+      inputEl.reportValidity();
+      isValid = false;
+    } else {
+      inputEl.setCustomValidity("");
+      inputEl.reportValidity();
+    }
+  }
+
+  return isValid;
+};


### PR DESCRIPTION
## Description
- `contact form`을 `common components`로 분리했습니다. (`inquiry`에 내용이 너무 많아보여서, 기능상 분리) 
- 유틸 함수 `validateForm`과 상수 `validationRule`을 추가해 전체 필드의 `required`, `email` 유효성 검사를 체크하도록 했습니다.
- 폼 제출시 로그인 유저의 `name`, `email` 필드도 초기화되는 문제를 수정했습니다.
- 폼 제출 성공시 렌더링될 모달 추가했습니다. 원래는 버튼이 홈으로 가기("/" redirect.. 아마도? 자세한 설명은 없었음)였는데 폼 제출하자마자 홈으로 갈 필요가 있는지... + 랜딩페이지에서도 사용되는 컴포넌트라서 그냥 닫기 버튼으로 만들었습니다.
- 에러 발생시 원래는 `useInquiryStore` 쪽에서 `alert` 하였으나 성공시 모달 오픈/에러시 경고 로직을 구분하기 위해 `store`에 `error state`를 추가하여 컴포넌트에서 `alert` 창을 띄우도록 변경했습니다. 

## Changes Made
- `validateForm`, `validationRule` 추가
- `contactForm`과 `Inquiry` 컴포넌트 분리 
- `Modal` 공통 컴포넌트의 `Title`과 `Desc`에서 `className`을 선택적으로 받을 수 있도록 수정 
- `SubmitContactFormModal` 컴포넌트 추가 
- `useInquiryStore` 수정 
- `inquiry.d.ts` 내부에 타입 추가 

## Screenshots

## IssueNumber

해당 이슈 넘버 ( #112 )
