### PR TITLE
[#112] auth middleware 추가

### DIFF
--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -1,0 +1,42 @@
+import { NextRequest, NextResponse } from "next/server";
+import { getToken } from "next-auth/jwt";
+
+const MAIN_PAGE = process.env.NEXTAUTH_URL ?? "";
+const SIGNIN_PAGE = `${MAIN_PAGE}/login`;
+const AUTH_PAGES = ["/login"];
+const PROTECTED_PATHS = ["/me", "/repos/", "/vuldb/items"];
+
+export async function middleware(req: NextRequest) {
+  const { pathname } = req.nextUrl;
+
+  const token = await getToken({ req });
+  if (AUTH_PAGES.some((page) => pathname.startsWith(page))) {
+    if (token) {
+      return NextResponse.redirect(MAIN_PAGE);
+    }
+    return NextResponse.next();
+  }
+
+  if (PROTECTED_PATHS.some((page) => pathname.startsWith(page))) {
+    if (!token) {
+      return NextResponse.redirect(SIGNIN_PAGE);
+    }
+  }
+
+  return NextResponse.next();
+}
+
+export const config = {
+  matcher: [
+    "/me/:path*",
+    "/repos/:path*",
+    "/vuldb/items/:path*",
+    {
+      source: "/((?!api|_next/static|_next/image|favicon.ico|server).*)",
+      missing: [
+        { type: "header", key: "next-router-prefetch" },
+        { type: "header", key: "purpose", value: "prefetch" },
+      ],
+    },
+  ],
+};


### PR DESCRIPTION
## Description
- 비로그인 상태에서 `/me`, `/me/*`, `/repos/*`, `/vuldb/items/*` 경로에 `url` 주소로 접근할 경우 `/login` 페이지로 강제 리다이렉트합니다.
- 로그인 상태에서 `/login` 페이지에 접근할 경우 `/` 메인페이지로 강제 리다이렉트합니다. 
- 기존에 작성하셨던 비로그인 체크 코드 삭제하셔도 됩니다! (해당 하위 페이지 대상)
- `/vuldb`와 `/repos`는 기획상 별도의 `ui`를 노출해야하므로 `protected paths`에 포함하지 않았습니다. 

## Changes Made
- `middleware.ts` 추가 

## Screenshots

## IssueNumber

해당 이슈 넘버 ( #112 )
