### PR TITLE
fix: css 일부 수정, hero 섹션 스크롤다운 버튼 위치 수정 

### DIFF
--- a/src/app/(home)/_components/HeroSection.tsx
+++ b/src/app/(home)/_components/HeroSection.tsx
@@ -2,7 +2,6 @@
 import Button from "@/components/common/Button";
 import WaveCircle from "@/components/common/WaveCircle";
 import { useSession } from "next-auth/react";
-import Image from "next/image";
 import Link from "next/link";
 import { useRef } from "react";
 import { HiOutlineChevronDoubleDown } from "react-icons/hi";
@@ -12,9 +11,10 @@ export default function HeroSection() {
   const flawSectionRef = useRef<HTMLDivElement | null>(null); // Ref를 생성하여 FindingFlawSection에 연결
   const scrollToNextSection = () => {
     if (flawSectionRef.current) {
+      const headerEl = document.getElementById("header");
+      const headerHeight = headerEl?.scrollHeight ?? 0;
       const componentHeight = flawSectionRef.current.scrollHeight; // 컴포넌트의 전체 높이 가져오기
-      const componentTop = flawSectionRef.current.offsetTop; // 컴포넌트의 최상단 위치 가져오기
-      const scrollPosition = componentTop + componentHeight; // 최상단 위치에 컴포넌트 전체 높이를 더해서 최하단 위치 계산
+      const scrollPosition = componentHeight + headerHeight; // 최상단 위치에 컴포넌트 전체 높이를 더해서 최하단 위치 계산
 
       window.scrollTo({
         top: scrollPosition, // 컴포넌트의 전체 높이만큼 스크롤

--- a/src/app/(home)/_components/HeroSection.tsx
+++ b/src/app/(home)/_components/HeroSection.tsx
@@ -28,7 +28,7 @@ export default function HeroSection() {
       <WaveCircle />
       <div className="z-20 flex w-full flex-col items-center justify-center gap-[20px]">
         <div className="text-4xl md:text-6xl">Find your Flaw,</div>
-        <div className="flex items-center justify-center rounded-full border-4 border-primary-purple-500 bg-white px-[15px] py-[10px] text-4xl tracking-wide dark:border-purple-50 dark:bg-custom-dark-bg md:px-[40px] md:py-[15px] md:text-6xl">
+        <div className="flex items-center justify-center rounded-full border-[3px] border-primary-purple-500 bg-white px-[15px] py-[10px] text-4xl tracking-wide dark:border-purple-50 dark:bg-custom-dark-bg md:border-4 md:px-[40px] md:py-[15px] md:text-6xl">
           FlawDetector
         </div>
         <p className="flex flex-col items-center pt-[10px] text-base md:text-xl lg:flex-row">

--- a/src/app/login/page.tsx
+++ b/src/app/login/page.tsx
@@ -1,22 +1,19 @@
-import { cookies } from "next/headers";
-import Image from "next/image";
 import { Login } from "./_components/Login";
-import { Logout } from "./_components/Logout";
 import WaveCircle from "@/components/common/WaveCircle";
 
 export default async function page() {
-  const cookieStore = cookies();
-  const sessionToken = cookieStore.get("next-auth.session-token");
-
   return (
     <section className="relative z-20 flex h-[84vh] w-full overflow-hidden text-primary-purple-500 dark:text-custom-dark-text">
       <WaveCircle />
-      <div className="z-20 flex w-full flex-col items-center justify-center gap-[40px] pb-[16vh]">
-        <div className="text-4xl md:text-5xl">Find your Flaw,</div>
-
-        <Login className="flex items-center justify-center rounded-full border-4 border-primary-purple-500 px-[25px] py-[10px] text-4xl dark:border-purple-50 dark:bg-custom-dark-bg dark:text-custom-dark-text hover:dark:bg-custom-dark-bg sm:px-[25px] sm:py-[10px] sm:text-4xl md:h-[110px] md:w-[240px] md:px-[40px] md:py-[20px] md:text-6xl">
-          Login
-        </Login>
+      <div className="z-20 flex w-full flex-col items-center justify-center gap-10 pb-[16vh]">
+        <div className="flex w-full flex-col items-center justify-center gap-6">
+          <div className="text-4xl font-normal md:text-6xl">
+            Find your Flaw,
+          </div>
+          <Login className="flex items-center justify-center rounded-full border-[3px] border-primary-purple-500 bg-white px-[25px] py-[10px] text-4xl font-normal text-primary-purple-500 hover:shadow-none dark:border-purple-50 dark:bg-custom-dark-bg dark:text-custom-dark-text hover:dark:bg-custom-dark-bg sm:px-[25px] sm:py-[10px] sm:text-4xl md:h-[110px] md:w-[240px] md:border-4 md:px-[40px] md:py-[20px] md:text-6xl">
+            Login
+          </Login>
+        </div>
         <Login>Github로 연동 로그인하기</Login>
       </div>
     </section>

--- a/src/components/common/Header.tsx
+++ b/src/components/common/Header.tsx
@@ -41,7 +41,10 @@ const Header: React.FC = () => {
       {modalOpen && (
         <LogoutConfirmModal isOpen={modalOpen} onClose={setModalOpen} />
       )}
-      <header className="sticky top-0 z-40 w-full border-b border-white bg-[rgba(255,255,255,0.16)] px-4 py-4 backdrop-blur-md dark:border-custom-dark-bg dark:bg-[rgba(0,0,0,0.16)] md:px-20 md:py-12">
+      <header
+        id="header"
+        className="sticky top-0 z-40 w-full border-b border-white bg-[rgba(255,255,255,0.16)] px-4 py-4 backdrop-blur-md dark:border-custom-dark-bg dark:bg-[rgba(0,0,0,0.16)] md:px-20 md:py-12"
+      >
         <div className="flex items-center justify-between text-custom-light-text dark:text-custom-dark-text">
           <Link href="/">
             <h1>

--- a/src/components/common/PcOnlyMessage.tsx
+++ b/src/components/common/PcOnlyMessage.tsx
@@ -2,16 +2,18 @@ import { FaDesktop } from "react-icons/fa";
 
 export default function PcOnlyMessage() {
   return (
-    <section className="flex h-[90vh] flex-col items-center justify-center gap-3 whitespace-nowrap p-5 sm:gap-6 xl:hidden">
-      <FaDesktop className="text-3xl text-primary-purple-500 sm:text-5xl" />
-      <h2 className="text-xl font-bold text-primary-purple-500 sm:text-2xl">
-        화면 크기를 조정해 주세요
-      </h2>
-      <p className="text-center text-sm text-grayscale-40 sm:text-base">
-        이 페이지는 가로 화면 크기 1280px 이상의 환경에 최적화되어 있습니다.
-        <br />
-        원활한 이용을 위해 권장 해상도로 브라우저 창을 조정해 주세요.
-      </p>
+    <section className="flex h-[93vh] flex-col items-center justify-center gap-6 whitespace-nowrap p-5 sm:h-[88vh] sm:gap-8 xl:hidden">
+      <FaDesktop className="h-20 w-20 text-primary-purple-500 dark:text-primary-purple-300 sm:text-5xl md:h-[100px] md:w-[100px]" />
+      <div className="flex flex-col items-center gap-4">
+        <h2 className="text-xl font-bold text-primary-purple-500 dark:text-primary-purple-300 sm:text-3xl">
+          화면 크기를 조정해 주세요
+        </h2>
+        <p className="text-center text-sm text-grayscale-40 dark:text-text-gray-default sm:text-base">
+          이 페이지는 가로 화면 크기 1280px 이상의 환경에 최적화되어 있습니다.
+          <br />
+          원활한 이용을 위해 권장 해상도로 브라우저 창을 조정해 주세요.
+        </p>
+      </div>
     </section>
   );
 }

--- a/src/components/common/chatbot/ChatContainer.tsx
+++ b/src/components/common/chatbot/ChatContainer.tsx
@@ -4,7 +4,7 @@ import ChatLog from "./ChatLog";
 
 export default function ChatContainer() {
   return (
-    <section className="ml-5 flex h-[620px] flex-col justify-between overflow-hidden rounded-3xl border border-white bg-white shadow-lg dark:border-primary-purple-300 dark:bg-grayscale-90 sm:ml-0 sm:w-[480px]">
+    <section className="ml-5 flex h-[620px] max-h-[80vh] flex-col justify-between overflow-hidden rounded-3xl border border-white bg-white shadow-lg dark:border-primary-purple-300 dark:bg-grayscale-90 sm:ml-0 sm:w-[480px]">
       <div className="flex h-[67px] w-full select-none items-center gap-[10px] bg-primary-purple-500 p-6 dark:bg-primary-purple-300">
         <IoChatbubble className="h-[32px] w-[32px] fill-white dark:fill-custom-dark-bg" />
         <p className="text-xl font-semibold text-white dark:text-custom-dark-bg">


### PR DESCRIPTION
## Description
- 다크모드 `css` 수정때문에 라이트모드에서 이상하게 노출되는 부분을 발견해서 수정했습니다!
- 반응형 관련 추가적으로 수가한 부분이 있습니다. (`hero` 섹션 `border` 등) 
- `PcOnlyMessage` 컴포넌트 아이콘, 텍스트, 간격 등을 `error`, `not-found` 페이지와 유사한 사이즈로 노출될 수 있도록 수정 + 다크모드 색상 변경했습니다. 
- `hero` 섹션 스크롤다운 버튼 클릭시 `top`이 정확하게 두 번째 섹션으로 이동하지 않는 문제를 수정했습니다. (`header` 높이 포함하여 이동) 
- 챗봇이 작은 모니터 환경에서도 최대한 정사이즈 노출될 수 있도록 반응형 수정했습니다. 

## Changes Made
- `ChatContainer`, `HeroSection`, `Login Page`, `LibraryLogin`, `PcOnlyMessage` 컴포넌트 `css` 수정
- `HeroSection` scroll button 스크롤 위치 수정 

## Screenshots

## IssueNumber

