### PR TITLE
add: components stories 추가, 에러 및 타입 수정

### DIFF
--- a/.storybook/preview.ts
+++ b/.storybook/preview.ts
@@ -9,6 +9,19 @@ const preview: Preview = {
         date: /Date$/i,
       },
     },
+    backgrounds: {
+      default: "light",
+      values: [
+        {
+          name: "light",
+          value: "#FFFFFF",
+        },
+        {
+          name: "dark",
+          value: "#121212",
+        },
+      ],
+    },
   },
 };
 

--- a/src/app/me/(me-layout)/scraps/_components/ArticleList.tsx
+++ b/src/app/me/(me-layout)/scraps/_components/ArticleList.tsx
@@ -5,7 +5,6 @@ import ClippingArticle from "./ClippingArticle";
 import Link from "next/link";
 import { useScrapStore } from "@/store/useScrapStore";
 import LoadingArticles from "./LoadingArticles";
-import { useEffect } from "react";
 import { TbArticleOff } from "react-icons/tb";
 import EmptyContent from "@/components/common/EmptyContent";
 
@@ -14,17 +13,14 @@ export default function ArticleList({
 }: {
   currentArticles: Article[];
 }) {
-  const { isLoading, error } = useScrapStore();
-  useEffect(() => {
-    console.log(isLoading);
-  }, [isLoading]);
+  const { status, error } = useScrapStore();
 
-  if (isLoading) return <LoadingArticles />;
+  if (status === "LOADING" || status === "IDLE") return <LoadingArticles />;
   if (error) return <p>{error}</p>;
 
   return (
     <>
-      {!isLoading && currentArticles.length === 0 && (
+      {status === "SUCCESS" && currentArticles.length === 0 && (
         <EmptyContent
           icon={
             <TbArticleOff className="h-16 w-16 text-text-gray-light dark:text-text-gray-dark" />
@@ -33,16 +29,18 @@ export default function ArticleList({
           스크랩한 게시물이 없어요.
         </EmptyContent>
       )}
-      <ul className="grid w-full grid-cols-3 gap-6">
-        {currentArticles &&
-          currentArticles.map((article) => (
-            <li key={article.id}>
-              <Link href={`/vuldb/items/${article.id}`}>
-                <ClippingArticle {...article} />
-              </Link>
-            </li>
-          ))}
-      </ul>
+      {currentArticles.length !== 0 && (
+        <ul className="grid w-full grid-cols-3 gap-6">
+          {currentArticles &&
+            currentArticles.map((article) => (
+              <li key={article.id}>
+                <Link href={`/vuldb/items/${article.id}`}>
+                  <ClippingArticle {...article} />
+                </Link>
+              </li>
+            ))}
+        </ul>
+      )}
     </>
   );
 }

--- a/src/app/me/(me-layout)/scraps/_components/ClippingArticle.tsx
+++ b/src/app/me/(me-layout)/scraps/_components/ClippingArticle.tsx
@@ -38,7 +38,10 @@ export default function ClippingArticle({
     <div className="flex h-[226px] w-full max-w-[422px] flex-col justify-between gap-6 rounded-xl border border-line-default p-7 hover:bg-bg-purple-light dark:border-opacity-20 dark:bg-custom-light-bg dark:bg-opacity-0 hover:dark:bg-opacity-5">
       <div className="flex flex-col items-start gap-2">
         <Label label={label} />
-        <h4 className="text-overflow h-[72px] text-2xl font-medium leading-normal text-black dark:text-custom-dark-text">
+        <h4
+          title={name}
+          className="text-overflow h-[72px] text-2xl font-medium leading-normal text-black dark:text-custom-dark-text"
+        >
           {name}
         </h4>
       </div>

--- a/src/app/me/(me-layout)/scraps/_components/ClippingArticle.tsx
+++ b/src/app/me/(me-layout)/scraps/_components/ClippingArticle.tsx
@@ -1,7 +1,13 @@
 import SuggestionChips from "@/components/common/chips/SuggestionChips";
 import { SuggestionChipsColor } from "@/types";
-import { Article } from "@/types/scrap";
+import { ArticleType } from "@/types/scrap";
 import { format } from "date-fns";
+
+type TClippingArticleProps = {
+  label: ArticleType;
+  name: string;
+  created_at: string;
+};
 
 function Label({ label }: { label: string }) {
   let type = "" as SuggestionChipsColor;
@@ -23,9 +29,13 @@ function Label({ label }: { label: string }) {
   return <SuggestionChips color={type}>{label}</SuggestionChips>;
 }
 
-export default function ClippingArticle({ label, name, created_at }: Article) {
+export default function ClippingArticle({
+  label,
+  name,
+  created_at,
+}: TClippingArticleProps) {
   return (
-    <div className="flex h-[226px] w-full flex-col justify-between gap-6 rounded-xl border border-line-default p-7 hover:bg-bg-purple-light dark:border-opacity-20 dark:bg-custom-light-bg dark:bg-opacity-0 hover:dark:bg-opacity-5">
+    <div className="flex h-[226px] w-full max-w-[422px] flex-col justify-between gap-6 rounded-xl border border-line-default p-7 hover:bg-bg-purple-light dark:border-opacity-20 dark:bg-custom-light-bg dark:bg-opacity-0 hover:dark:bg-opacity-5">
       <div className="flex flex-col items-start gap-2">
         <Label label={label} />
         <h4 className="text-overflow h-[72px] text-2xl font-medium leading-normal text-black dark:text-custom-dark-text">

--- a/src/app/me/(me-layout)/scraps/_components/LoadingArticles.tsx
+++ b/src/app/me/(me-layout)/scraps/_components/LoadingArticles.tsx
@@ -18,7 +18,7 @@ function LoadingArticle() {
 export default function LoadingArticles() {
   const items = Array.from({ length: 6 }, (_, index) => index);
   return (
-    <div className="grid w-full grid-cols-3 gap-6">
+    <div className="grid w-full min-w-[980px] grid-cols-3 gap-6">
       {items.map((item) => (
         <LoadingArticle key={item} />
       ))}

--- a/src/app/me/(me-layout)/setting/_components/EmailToggle.tsx
+++ b/src/app/me/(me-layout)/setting/_components/EmailToggle.tsx
@@ -1,5 +1,17 @@
 type TToggleProps = {} & React.ComponentPropsWithoutRef<"input">;
 
+export function Toggle({ ...rest }: TToggleProps) {
+  return (
+    <input
+      role="switch"
+      type="checkbox"
+      disabled
+      className="relative h-7 w-12 cursor-pointer appearance-none rounded-full border-2 border-line-dark bg-primary-purple-50 before:absolute before:left-0 before:h-6 before:w-6 before:scale-[0.6] before:rounded-full before:bg-[#797472] before:transition-all before:content-[''] checked:border-primary-purple-500 checked:bg-primary-purple-500 checked:before:left-5 checked:before:scale-[0.8] checked:before:bg-white hover:before:bg-text-gray-dark hover:before:shadow-[0_0_0_15px_rgba(29,27,32,0.08)] hover:checked:before:bg-primary-purple-50 hover:checked:before:shadow-[0_0_0_8px_rgba(103,80,164,0.08)] focus:before:shadow-[0_0_0_15px_rgba(201,168,255,0.50)] focus:checked:before:shadow-[0_0_0_8px_rgba(166,111,255,0.12)] active:before:scale-[0.9] active:before:shadow-[0_0_0_6px_rgba(201,168,255,0.50)] active:checked:before:scale-[0.9] active:checked:before:shadow-[0_0_0_6px_rgba(166,111,255,0.12)] disabled:cursor-default disabled:border-primary-purple-200 disabled:border-opacity-50 disabled:bg-bg-purple-light disabled:before:scale-[0.6] disabled:before:bg-[#1d1b20] disabled:before:bg-opacity-[0.38] disabled:before:shadow-none disabled:checked:border-primary-purple-200 disabled:checked:border-opacity-0 disabled:checked:bg-primary-purple-200 disabled:checked:bg-opacity-50 disabled:checked:before:scale-[0.8] disabled:checked:before:bg-bg-purple-light disabled:checked:before:bg-opacity-100 disabled:checked:before:shadow-none dark:bg-opacity-10 dark:checked:bg-opacity-100 dark:disabled:bg-opacity-20"
+      {...rest}
+    />
+  );
+}
+
 export default function EmailToggle({ ...rest }: TToggleProps) {
   return (
     <label className="flex w-full cursor-default items-center justify-between">

--- a/src/app/me/(me-layout)/setting/page.tsx
+++ b/src/app/me/(me-layout)/setting/page.tsx
@@ -1,13 +1,8 @@
 import PageTitle from "@/components/common/PageTitle";
 import EmailToggle from "./_components/EmailToggle";
-import { getServerSession } from "next-auth";
-import { authOptions } from "@/lib/auth";
 import UserItemWithLogout from "@/app/repos/_components/UserItemWithLogout";
 
 export default async function SettingPage() {
-  const session = await getServerSession(authOptions);
-  const { user } = session ?? {};
-
   return (
     <>
       <PageTitle>Setting</PageTitle>

--- a/src/app/repos/_components/LoadingRepo.tsx
+++ b/src/app/repos/_components/LoadingRepo.tsx
@@ -18,7 +18,7 @@ export default function LoadingRepository() {
   const items = Array.from({ length: 12 }, (_, index) => index);
 
   return (
-    <div className="grid w-full grid-cols-4 gap-6">
+    <div className="grid w-full min-w-[980px] grid-cols-4 gap-6">
       {items.map((item) => (
         <LoadingRepo key={item} />
       ))}

--- a/src/app/repos/_components/LoadingRepo.tsx
+++ b/src/app/repos/_components/LoadingRepo.tsx
@@ -6,7 +6,7 @@ function LoadingRepo() {
   return (
     <LoadingBox className="h-[225px]">
       <div className="h-8 w-32 rounded-xl bg-grayscale-10 dark:bg-grayscale-80" />
-      <div className="flex items-end justify-between">
+      <div className="flex items-end justify-between gap-2">
         <div className="h-[48px] w-[148px] rounded-[14px] bg-grayscale-10 dark:bg-grayscale-80" />
         <div className="invisible h-5 w-12 rounded-xl bg-grayscale-10 dark:bg-grayscale-80 xl:visible" />
       </div>

--- a/src/app/repos/_components/ReposLibrary.tsx
+++ b/src/app/repos/_components/ReposLibrary.tsx
@@ -16,13 +16,8 @@ export default function ReposLibrary() {
     [],
   );
   const { repositories, fetchRepositories } = useGithubStore();
-  const {
-    status,
-    fetchReposData,
-    currentPage,
-    setCurrentPage,
-    ITEMS_PER_PAGE,
-  } = useLibraryStore();
+  const { fetchReposData, currentPage, setCurrentPage, ITEMS_PER_PAGE } =
+    useLibraryStore();
   const { reposItemsPerPage } = usePaginationStore();
   const { email } = useGetUser();
 

--- a/src/app/repos/_components/RepositoryChip.tsx
+++ b/src/app/repos/_components/RepositoryChip.tsx
@@ -24,7 +24,7 @@ export default function RepositoryChip({ type }: { type?: RepositoryStatus }) {
   return (
     <div
       className={twMerge(
-        "flex w-auto items-center justify-center rounded-full px-3 py-2 text-base font-medium tracking-tight dark:border dark:bg-transparent",
+        "flex items-center justify-center self-start rounded-full px-3 py-2 text-base font-medium tracking-tight dark:border dark:bg-transparent",
         style,
       )}
     >

--- a/src/app/repos/_components/RepositoryItem.tsx
+++ b/src/app/repos/_components/RepositoryItem.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { RepositoryProps, RepositoryStatus } from "@/types";
+import { RepositoryStatus } from "@/types";
 import RepositoryChip from "./RepositoryChip";
 import BookmarkButton from "./BookmarkButton";
 import { format } from "date-fns";
@@ -12,7 +12,10 @@ type TRepositoryItemProps = {
     recent?: boolean;
     status?: RepositoryStatus;
   };
-} & RepositoryProps;
+  name: string;
+  owner: { login: string };
+  created_at: string;
+};
 
 export default function RepositoryItem({
   name,

--- a/src/app/repos/_components/RepositoryItem.tsx
+++ b/src/app/repos/_components/RepositoryItem.tsx
@@ -26,20 +26,18 @@ export default function RepositoryItem({
   return (
     <div className="group flex h-[225px] w-full flex-col justify-between rounded-xl border border-primary-purple-100 p-5 hover:bg-bg-purple-light dark:border-opacity-20 dark:bg-custom-light-bg dark:bg-opacity-0 hover:dark:bg-opacity-5">
       <div className="flex flex-col gap-1">
-        <div className="flex w-full items-center justify-between gap-4">
-          {matchData?.status && <RepositoryChip type={matchData?.status} />}
-          {!matchData?.status && (
-            <h4 className="max-w-[270px] truncate text-[28px] font-medium leading-[48px] text-text-gray-dark dark:text-text-gray-light">
+        <div className="align-start flex w-full gap-4">
+          <div className="flex flex-grow flex-col gap-1">
+            {matchData?.status && <RepositoryChip type={matchData?.status} />}
+            <h4
+              title={name}
+              className="max-w-[150px] truncate text-[28px] font-medium leading-[48px] text-text-gray-dark dark:text-text-gray-light"
+            >
               {name}
             </h4>
-          )}
+          </div>
           <BookmarkButton bookmark={matchData?.bookmark} name={name} />
         </div>
-        {matchData?.status && (
-          <h4 className="max-w-[270px] truncate text-[28px] font-medium text-text-gray-dark dark:text-text-gray-light">
-            name
-          </h4>
-        )}
       </div>
       <div className="flex items-end justify-between gap-2">
         <DetectLink

--- a/src/app/repos/_components/RepositoryItem.tsx
+++ b/src/app/repos/_components/RepositoryItem.tsx
@@ -41,7 +41,7 @@ export default function RepositoryItem({
           </h4>
         )}
       </div>
-      <div className="flex items-end justify-between">
+      <div className="flex items-end justify-between gap-2">
         <DetectLink
           status={matchData?.status}
           recent={matchData?.recent}

--- a/src/app/repos/_components/RepositoryList.tsx
+++ b/src/app/repos/_components/RepositoryList.tsx
@@ -32,6 +32,15 @@ export default function RepositoryList({
 
   return (
     <ul className="grid w-full grid-cols-4 gap-6">
+      {status === "SUCCESS" && currentRepos.length === 0 && (
+        <EmptyContent
+          icon={
+            <MdOutlineFolderOff className="h-16 w-16 text-text-gray-light dark:text-text-gray-dark" />
+          }
+        >
+          조건에 해당하는 데이터가 없어요.
+        </EmptyContent>
+      )}
       {currentRepos.length !== 0 &&
         currentRepos.map((repo, index) => {
           const matchData = findMatchData(repo, reposData);

--- a/src/app/repos/_components/RepositoryList.tsx
+++ b/src/app/repos/_components/RepositoryList.tsx
@@ -14,12 +14,12 @@ export default function RepositoryList({
 }: {
   currentRepos: RepositoryProps[];
 }) {
-  const { isLoading, error } = useGithubStore();
-  const { reposData } = useLibraryStore();
+  const { error } = useGithubStore();
+  const { reposData, status } = useLibraryStore();
 
-  if (isLoading) return <LoadingRepository />;
+  if (status === "LOADING" || status === "IDLE") return <LoadingRepository />;
   if (error) return <div>{error}</div>;
-  if (currentRepos.length === 0)
+  if (status === "SUCCESS" && currentRepos.length === 0)
     return (
       <EmptyContent
         icon={

--- a/src/components/common/Input.tsx
+++ b/src/components/common/Input.tsx
@@ -8,7 +8,7 @@ export default function Input({ className, ...rest }: TInputProps) {
   return (
     <input
       className={twMerge(
-        "font-base w-full rounded-lg border border-line-gray-10 p-3 text-lg text-custom-light-text outline-none placeholder:text-text-gray-light valid:bg-bg-purple-light valid:placeholder-shown:bg-transparent invalid:border-accent-red invalid:bg-bg-red-light focus:border-primary-purple-500 disabled:bg-bg-gray-light dark:border-custom-light-text dark:bg-transparent dark:text-text-gray-light dark:placeholder:text-custom-light-text dark:valid:bg-bg-purple-light dark:valid:bg-opacity-5 dark:invalid:border-accent-red dark:invalid:bg-bg-red-light dark:invalid:bg-opacity-5 dark:focus:border-primary-purple-300 dark:disabled:bg-bg-gray-light dark:disabled:bg-opacity-5",
+        "font-base w-full rounded-lg border border-line-gray-10 p-3 text-lg text-custom-light-text outline-none placeholder:text-text-gray-light valid:bg-bg-purple-light valid:placeholder-shown:bg-transparent invalid:border-accent-red invalid:bg-bg-red-light focus:border-primary-purple-500 disabled:bg-bg-gray-light dark:border-custom-light-text dark:bg-transparent dark:text-text-gray-light dark:placeholder:text-text-gray-default dark:valid:bg-bg-purple-light dark:valid:bg-opacity-5 dark:invalid:border-accent-red dark:invalid:bg-bg-red-light dark:invalid:bg-opacity-5 dark:focus:border-primary-purple-300 dark:disabled:bg-bg-gray-light dark:disabled:bg-opacity-5",
         className,
       )}
       {...rest}

--- a/src/components/common/Textarea.tsx
+++ b/src/components/common/Textarea.tsx
@@ -8,7 +8,7 @@ export default function Textarea({ className, ...rest }: TTextareaProps) {
   return (
     <textarea
       className={twMerge(
-        "font-base w-full resize-none rounded-lg border border-line-gray-10 bg-transparent p-3 text-lg text-custom-light-text outline-none placeholder:text-text-gray-light valid:bg-bg-purple-light valid:placeholder-shown:bg-transparent invalid:border-accent-red invalid:bg-bg-red-light focus:border-primary-purple-500 disabled:bg-bg-gray-light dark:border-custom-light-text dark:bg-transparent dark:text-text-gray-light dark:placeholder:text-custom-light-text dark:valid:bg-bg-purple-light dark:valid:bg-opacity-5 dark:invalid:border-accent-red dark:invalid:bg-bg-red-light dark:invalid:bg-opacity-5 dark:focus:border-primary-purple-300 dark:disabled:bg-bg-gray-light dark:disabled:bg-opacity-5",
+        "font-base w-full resize-none rounded-lg border border-line-gray-10 bg-transparent p-3 text-lg text-custom-light-text outline-none placeholder:text-text-gray-light valid:bg-bg-purple-light valid:placeholder-shown:bg-transparent invalid:border-accent-red invalid:bg-bg-red-light focus:border-primary-purple-500 disabled:bg-bg-gray-light dark:border-custom-light-text dark:bg-transparent dark:text-text-gray-light dark:placeholder:text-text-gray-default dark:valid:bg-bg-purple-light dark:valid:bg-opacity-5 dark:invalid:border-accent-red dark:invalid:bg-bg-red-light dark:invalid:bg-opacity-5 dark:focus:border-primary-purple-300 dark:disabled:bg-bg-gray-light dark:disabled:bg-opacity-5",
         className,
       )}
       {...rest}

--- a/src/components/common/UserPic.tsx
+++ b/src/components/common/UserPic.tsx
@@ -1,15 +1,17 @@
 import Image from "next/image";
 import { twMerge } from "tailwind-merge";
 
+type TUserPicProps = {
+  image?: string;
+  name: string;
+  size?: "small" | "large";
+};
+
 export default function UserPic({
   image,
   name,
   size = "large",
-}: {
-  image?: string;
-  name: string;
-  size?: "small" | "large";
-}) {
+}: TUserPicProps) {
   return (
     <div
       className={twMerge(

--- a/src/store/useLibraryStore.ts
+++ b/src/store/useLibraryStore.ts
@@ -17,6 +17,7 @@ export const useLibraryStore = create<LibraryState>((set, get) => ({
   fetchReposData: async (email) => {
     set({
       status: "LOADING",
+      error: null,
     });
     try {
       const repos = await getReposData(email);

--- a/src/store/useLibraryStore.ts
+++ b/src/store/useLibraryStore.ts
@@ -3,7 +3,8 @@ import { LibraryState } from "@/types/library";
 import { create } from "zustand";
 
 export const useLibraryStore = create<LibraryState>((set, get) => ({
-  status: { isLoading: false, error: null },
+  status: "IDLE",
+  error: null,
   libraryState: { recent: false, bookmark: false },
   ITEMS_PER_PAGE: 16,
   currentPage: 1,
@@ -15,14 +16,15 @@ export const useLibraryStore = create<LibraryState>((set, get) => ({
   setCurrentPage: (page) => set({ currentPage: page }),
   fetchReposData: async (email) => {
     set({
-      status: { isLoading: true, error: null },
+      status: "LOADING",
     });
     try {
       const repos = await getReposData(email);
-      set({ reposData: repos, status: { isLoading: false, error: null } });
+      set({ reposData: repos, status: "SUCCESS" });
     } catch (error) {
       set({
-        status: { isLoading: false, error: (error as Error).message },
+        status: "ERROR",
+        error: (error as Error).message,
       });
     }
   },

--- a/src/store/useScrapStore.ts
+++ b/src/store/useScrapStore.ts
@@ -3,19 +3,19 @@ import { ScrapState } from "@/types/scrap";
 import { create } from "zustand";
 
 export const useScrapStore = create<ScrapState>((set) => ({
-  isLoading: false,
+  status: "IDLE",
   error: null,
   scraps: [],
   ITEMS_PER_PAGE: 12,
   currentPage: 1,
   setCurrentPage: (page) => set({ currentPage: page }),
   fetchScraps: async (email) => {
-    set({ isLoading: true, error: null });
+    set({ status: "LOADING", error: null });
     try {
       const articles = await getScrapPosts(email);
-      set({ scraps: articles, isLoading: false });
+      set({ scraps: articles, status: "SUCCESS" });
     } catch (error) {
-      set({ error: (error as Error).message, isLoading: false });
+      set({ error: (error as Error).message, status: "ERROR" });
       throw new Error("Failed to fetch scraps data.");
     }
   },

--- a/src/stories/AskButton.stories.tsx
+++ b/src/stories/AskButton.stories.tsx
@@ -1,5 +1,6 @@
 import AskButton from "@/components/common/AskButton";
 import { Meta, StoryObj } from "@storybook/react";
+import { ThemeProvider } from "next-themes";
 
 const meta: Meta<typeof AskButton> = {
   title: "common/Buttons/AskButton",
@@ -8,16 +9,35 @@ const meta: Meta<typeof AskButton> = {
     layout: "padded",
   },
   tags: ["autodocs"],
+  decorators: [
+    (Story) => (
+      <ThemeProvider>
+        <div className="h-[700px]">
+          <Story />
+        </div>
+      </ThemeProvider>
+    ),
+  ],
 };
 
 export default meta;
 
 type Story = StoryObj<typeof meta>;
 
-export const Default: Story = {
-  render: () => (
-    <div className="h-[500px]">
-      <AskButton />
-    </div>
-  ),
+export const Default: Story = {};
+
+export const DarkMode: Story = {
+  args: {},
+  parameters: {
+    backgrounds: { default: "dark" },
+  },
+  decorators: [
+    (Story) => (
+      <ThemeProvider forcedTheme="dark">
+        <div className="dark">
+          <Story />
+        </div>
+      </ThemeProvider>
+    ),
+  ],
 };

--- a/src/stories/ClippingArticle.stories.tsx
+++ b/src/stories/ClippingArticle.stories.tsx
@@ -1,0 +1,82 @@
+import type { Meta, StoryObj } from "@storybook/react";
+import ClippingArticle from "@/app/me/(me-layout)/scraps/_components/ClippingArticle";
+import { ThemeProvider } from "next-themes";
+import { SessionProvider } from "next-auth/react";
+
+const meta = {
+  title: "Scrap/ClippingArticle",
+  component: ClippingArticle,
+  parameters: {
+    layout: "centered",
+  },
+  tags: ["autodocs"],
+  argTypes: {
+    label: {
+      action: "clicked",
+      description: "온클릭 액션",
+    },
+    name: {
+      control: "object",
+      description: "필터링된 레포지토리 배열",
+    },
+    created_at: { action: "clicked", description: "온클릭 액션" },
+  },
+  args: {
+    label: "취약성 보고서",
+    name: "A 기업 취약성 보고서",
+    created_at: "2024-10-04 11:22",
+  },
+  decorators: [
+    (Story) => (
+      <SessionProvider>
+        <ThemeProvider>
+          <Story />
+        </ThemeProvider>
+      </SessionProvider>
+    ),
+  ],
+} satisfies Meta<typeof ClippingArticle>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Report: Story = {
+  args: {},
+};
+
+export const Notice: Story = {
+  args: {
+    label: "취약성 알림",
+    name: "A 기업 취약성 알림",
+  },
+};
+
+export const Warning: Story = {
+  args: {
+    label: "취약성 경고",
+    name: "A 기업 취약성 경고",
+  },
+};
+
+export const Other: Story = {
+  args: {
+    label: "기타",
+    name: "2줄 이상의 텍스트까지 표시되며 그 이상의 텍스트는 생략됩니다. 예를들어",
+  },
+};
+
+export const DarkMode: Story = {
+  args: {},
+  parameters: {
+    backgrounds: { default: "dark" },
+  },
+  decorators: [
+    (Story) => (
+      <ThemeProvider forcedTheme="dark">
+        <div className="dark">
+          <Story />
+        </div>
+      </ThemeProvider>
+    ),
+  ],
+};

--- a/src/stories/Dropdown.stories.tsx
+++ b/src/stories/Dropdown.stories.tsx
@@ -1,9 +1,11 @@
-import React from "react";
-import type { Meta, StoryObj } from "@storybook/react";
+import React, { useState } from "react";
+import type { Meta, StoryFn } from "@storybook/react";
 import Dropdown from "../components/common/Dropdown";
+import { fn } from "@storybook/test";
+import { TDropdownSelect } from "@/app/repos/_components/LibraryToolbar";
 import { ThemeProvider } from "next-themes";
 
-const meta: Meta<typeof Dropdown> = {
+const meta = {
   title: "common/Dropdown",
   component: Dropdown,
   parameters: {
@@ -11,35 +13,92 @@ const meta: Meta<typeof Dropdown> = {
   },
   tags: ["autodocs"],
   argTypes: {
+    id: {
+      control: "text",
+      description: "드롭다운 id 지정",
+    },
+    selectedOption: {
+      control: "text",
+      defaultValue: "Sort",
+      description: "선택된 옵션 텍스트 노출",
+    },
+    options: {
+      control: "object",
+      description: "드롭다운 옵션 리스트",
+      defaultValue: ["최신순", "오래된순", "이름순"],
+    },
+    onSelect: {
+      action: "clicked",
+      description: "옵션 선택 온클릭 이벤트",
+    },
+    openDropdownId: {
+      control: "text",
+      description: "현재 오픈된 드롭다운 id",
+    },
+    setOpenDropdownId: {
+      action: "clicked",
+      description: "오픈된 드롭다운 id 변경 이벤트",
+    },
     type: {
-      control: { type: "radio" },
-      options: ["Type", "Sort"],
+      control: "radio",
+      options: ["sort", "type"],
+      description: "드롭다운 종류",
     },
   },
-  decorators: [
-    (Story) => (
-      <ThemeProvider attribute="class">
-        <div className="p-4">
-          <Story />
-        </div>
-      </ThemeProvider>
-    ),
-  ],
-};
-
-export default meta;
-type Story = StoryObj<typeof Dropdown>;
-
-// 기본 스토리
-export const Default: Story = {
   args: {
-    type: "type",
-  },
-};
-
-// Sort 옵션 스토리
-export const Sort: Story = {
-  args: {
+    onSelect: fn(),
+    setOpenDropdownId: fn(),
+    options: ["최신순", "오래된순", "이름순"],
+    id: "dropdown-sort",
     type: "sort",
   },
+} satisfies Meta<typeof Dropdown>;
+
+export default meta;
+
+const Template: StoryFn<typeof Dropdown> = (args) => {
+  const [openDropdownId, setOpenDropdownId] = useState<string | null>(null);
+  const [selectedItem, setSelectedItem] = useState<TDropdownSelect>({
+    type: "Type",
+    sort: "Sort",
+  });
+
+  return (
+    <ThemeProvider>
+      <div className="flex h-[400px] w-full justify-center">
+        <Dropdown
+          id={args.id}
+          selectedOption={selectedItem[args.type as "type" | "sort"]}
+          onSelect={(option) => {
+            setSelectedItem((prev) => ({
+              ...prev,
+              [args.type]: option,
+            }));
+          }}
+          options={args.options}
+          openDropdownId={openDropdownId}
+          setOpenDropdownId={setOpenDropdownId}
+          type={args.type}
+        />
+      </div>
+    </ThemeProvider>
+  );
 };
+
+export const Default = Template.bind({});
+Default.args = {};
+
+export const DarkMode = Template.bind({});
+DarkMode.args = {};
+DarkMode.parameters = {
+  backgrounds: { default: "dark" },
+};
+DarkMode.decorators = [
+  (Story) => (
+    <ThemeProvider forcedTheme="dark">
+      <div className="dark">
+        <Story />
+      </div>
+    </ThemeProvider>
+  ),
+];

--- a/src/stories/Input.stories.tsx
+++ b/src/stories/Input.stories.tsx
@@ -1,37 +1,40 @@
 import type { Meta, StoryObj } from "@storybook/react";
 import Input from "@/components/common/Input";
+import { ThemeProvider } from "next-themes";
 
 const meta = {
   title: "common/Input",
   component: Input,
+  tags: ["autodocs"],
   parameters: {
     layout: "centered",
   },
-  tags: ["autodocs"],
   argTypes: {
     className: {
       control: "text",
-      type: "string",
       description:
         "옵셔널한 값으로 필요한 경우 className을 통해 Input에 추가적인 tailwindCSS 속성을 부여합니다.",
     },
-    placeholder: { control: "text", type: "string" },
-    value: { control: "text", type: "string" },
+    placeholder: {
+      control: "text",
+      description: "플레이스홀더 텍스트",
+      defaultValue: "내용을 입력해 주세요.",
+    },
+    value: { control: "text", type: "string", description: "인풋 밸류" },
     type: {
       control: "select",
-      type: "string",
       options: ["text", "email", "password"],
       description: "input 타입을 지정합니다.",
     },
     disabled: {
       control: "boolean",
-      type: "boolean",
       description: "옵셔널한 값으로 disabled 상태가 필요할 때 사용합니다.",
+      defaultValue: false,
     },
     required: {
       control: "boolean",
-      type: "boolean",
       description: "옵셔널한 값으로 required 체크가 필요할 때 사용합니다.",
+      defaultValue: false,
     },
   },
   args: {
@@ -40,6 +43,13 @@ const meta = {
     className: "w-[300px]",
     placeholder: "내용을 입력해 주세요.",
   },
+  decorators: [
+    (Story) => (
+      <ThemeProvider>
+        <Story />
+      </ThemeProvider>
+    ),
+  ],
 } satisfies Meta<typeof Input>;
 
 export default meta;
@@ -70,4 +80,22 @@ export const Disabled: Story = {
     type: "text",
     disabled: true,
   },
+};
+
+export const DarkMode: Story = {
+  args: {
+    type: "text",
+  },
+  parameters: {
+    backgrounds: { default: "dark" },
+  },
+  decorators: [
+    (Story) => (
+      <ThemeProvider forcedTheme="dark">
+        <div className="dark">
+          <Story />
+        </div>
+      </ThemeProvider>
+    ),
+  ],
 };

--- a/src/stories/LoadingArticles.stories.tsx
+++ b/src/stories/LoadingArticles.stories.tsx
@@ -1,0 +1,44 @@
+import type { Meta, StoryObj } from "@storybook/react";
+import LoadingArticles from "@/app/me/(me-layout)/scraps/_components/LoadingArticles";
+import { ThemeProvider } from "next-themes";
+
+const meta = {
+  title: "Scrap/LoadingArticles",
+  component: LoadingArticles,
+  tags: ["autodocs"],
+  parameters: {
+    layout: "centered",
+  },
+  decorators: [
+    (Story) => (
+      <ThemeProvider>
+        <div className="w-[1280px]">
+          <Story />
+        </div>
+      </ThemeProvider>
+    ),
+  ],
+} satisfies Meta<typeof LoadingArticles>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Basic: Story = {
+  args: {},
+};
+
+export const DarkMode: Story = {
+  args: {},
+  parameters: {
+    backgrounds: { default: "dark" },
+  },
+  decorators: [
+    (Story) => (
+      <ThemeProvider forcedTheme="dark">
+        <div className="dark">
+          <Story />
+        </div>
+      </ThemeProvider>
+    ),
+  ],
+};

--- a/src/stories/LoadingRepo.stories.tsx
+++ b/src/stories/LoadingRepo.stories.tsx
@@ -1,0 +1,44 @@
+import type { Meta, StoryObj } from "@storybook/react";
+import LoadingRepo from "@/app/repos/_components/LoadingRepo";
+import { ThemeProvider } from "next-themes";
+
+const meta = {
+  title: "Repository/LoadingRepo",
+  component: LoadingRepo,
+  tags: ["autodocs"],
+  parameters: {
+    layout: "centered",
+  },
+  decorators: [
+    (Story) => (
+      <ThemeProvider>
+        <div className="w-[1280px]">
+          <Story />
+        </div>
+      </ThemeProvider>
+    ),
+  ],
+} satisfies Meta<typeof LoadingRepo>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Basic: Story = {
+  args: {},
+};
+
+export const DarkMode: Story = {
+  args: {},
+  parameters: {
+    backgrounds: { default: "dark" },
+  },
+  decorators: [
+    (Story) => (
+      <ThemeProvider forcedTheme="dark">
+        <div className="dark">
+          <Story />
+        </div>
+      </ThemeProvider>
+    ),
+  ],
+};

--- a/src/stories/Modal.stories.tsx
+++ b/src/stories/Modal.stories.tsx
@@ -2,6 +2,7 @@ import React, { useState } from "react";
 import { Meta, StoryFn } from "@storybook/react";
 import Modal from "@/components/common/Modal";
 import Button from "@/components/common/Button";
+import { ThemeProvider } from "next-themes";
 
 const meta = {
   title: "common/Modal",
@@ -13,19 +14,16 @@ const meta = {
   argTypes: {
     shadow: {
       control: "boolean",
-      type: "boolean",
       description:
         "옵셔널한 값으로 modal container의 shadow를 선택할 수 있습니다.",
     },
     dimmed: {
       control: "boolean",
-      type: "boolean",
       description:
         "옵셔널한 값으로 modal container 뒷부분의 dimmed 처리를 선택할 수 있습니다.",
     },
     className: {
       control: "text",
-      type: "string",
       description:
         "옵셔널한 값으로 필요한 경우 className을 통해 Modal에 추가적인 tailwindCSS 속성을 부여합니다.",
     },
@@ -34,7 +32,6 @@ const meta = {
     },
     children: {
       control: "text",
-      type: "string",
       description:
         "모달 내부에 전달될 아이템을 정의합니다. <Modal.Title>, <Modal.Desc>, <Modal.Box>, <Modal.Button>, <Modal.Content>",
     },
@@ -46,6 +43,13 @@ const meta = {
   args: {
     className: "w-[400px]",
   },
+  decorators: [
+    (Story) => (
+      <ThemeProvider>
+        <Story />
+      </ThemeProvider>
+    ),
+  ],
 } satisfies Meta<typeof Modal>;
 
 export default meta;
@@ -79,7 +83,7 @@ const Template: StoryFn<typeof Modal> = (args) => {
             </Modal.Desc>
           </Modal.Box>
           <Modal.Content>
-            <div className="flex w-full flex-col items-center justify-center border border-black py-4">
+            <div className="flex w-full flex-col items-center justify-center border border-black py-4 dark:text-text-gray-default">
               <p>Content</p>
               <p>필요한 아이템을 넣을 수 있어요.</p>
             </div>
@@ -105,3 +109,21 @@ Default.args = {
   shadow: true,
   dimmed: true,
 };
+
+export const DarkMode = Template.bind({});
+DarkMode.args = {
+  shadow: false,
+  dimmed: false,
+};
+DarkMode.parameters = {
+  backgrounds: { default: "dark" },
+};
+DarkMode.decorators = [
+  (Story) => (
+    <ThemeProvider forcedTheme="dark">
+      <div className="dark">
+        <Story />
+      </div>
+    </ThemeProvider>
+  ),
+];

--- a/src/stories/ReposFilterButtons.stories.tsx
+++ b/src/stories/ReposFilterButtons.stories.tsx
@@ -1,0 +1,60 @@
+import type { Meta, StoryObj } from "@storybook/react";
+import ReposFilterButtons from "@/app/repos/_components/ReposFilterButtons";
+import { ThemeProvider } from "next-themes";
+import { SessionProvider } from "next-auth/react";
+import { fn } from "@storybook/test";
+
+const meta = {
+  title: "Repository/ReposFilterButtons",
+  component: ReposFilterButtons,
+  parameters: {
+    layout: "centered",
+  },
+  tags: ["autodocs"],
+  argTypes: {
+    setRepos: {
+      action: "clicked",
+      description: "온클릭 액션",
+    },
+    repositories: {
+      control: "object",
+      description: "필터링된 레포지토리 배열",
+    },
+  },
+  args: {
+    setRepos: fn,
+    repositories: [],
+  },
+  decorators: [
+    (Story) => (
+      <SessionProvider>
+        <ThemeProvider>
+          <Story />
+        </ThemeProvider>
+      </SessionProvider>
+    ),
+  ],
+} satisfies Meta<typeof ReposFilterButtons>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
+  args: {},
+};
+
+export const DarkMode: Story = {
+  args: {},
+  parameters: {
+    backgrounds: { default: "dark" },
+  },
+  decorators: [
+    (Story) => (
+      <ThemeProvider forcedTheme="dark">
+        <div className="dark">
+          <Story />
+        </div>
+      </ThemeProvider>
+    ),
+  ],
+};

--- a/src/stories/RepositoryItem.stories.tsx
+++ b/src/stories/RepositoryItem.stories.tsx
@@ -1,0 +1,82 @@
+import type { Meta, StoryObj } from "@storybook/react";
+import RepositoryItem from "@/app/repos/_components/RepositoryItem";
+import { ThemeProvider } from "next-themes";
+import { SessionProvider } from "next-auth/react";
+
+const meta = {
+  title: "Repository/RepositoryItem",
+  component: RepositoryItem,
+  parameters: {
+    layout: "centered",
+  },
+  tags: ["autodocs"],
+  argTypes: {
+    name: {
+      control: "text",
+      description: "레포지토리 타이틀",
+    },
+    owner: {
+      control: "object",
+      description: "레포지토리 소유자",
+    },
+    created_at: { control: "text", description: "레포지토리 생성일" },
+    matchData: {
+      control: "object",
+      description:
+        "DB 매치데이터로 북마크(true/false)와 status 상태 칩(IN_PROGRESS/COMPLETED) 상태 변경",
+    },
+  },
+  args: {
+    name: "project-1",
+    owner: { login: "john" },
+    created_at: "2024-10-11 13:22",
+    matchData: {
+      bookmark: false,
+      status: undefined,
+    },
+  },
+  decorators: [
+    (Story) => (
+      <SessionProvider>
+        <ThemeProvider>
+          <Story />
+        </ThemeProvider>
+      </SessionProvider>
+    ),
+  ],
+} satisfies Meta<typeof RepositoryItem>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
+  args: {},
+};
+
+export const Bookmarked: Story = {
+  args: { matchData: { bookmark: true } },
+};
+
+export const InProgress: Story = {
+  args: { matchData: { status: "IN_PROGRESS" } },
+};
+
+export const Completed: Story = {
+  args: { matchData: { status: "COMPLETED" } },
+};
+
+export const DarkMode: Story = {
+  args: {},
+  parameters: {
+    backgrounds: { default: "dark" },
+  },
+  decorators: [
+    (Story) => (
+      <ThemeProvider forcedTheme="dark">
+        <div className="dark">
+          <Story />
+        </div>
+      </ThemeProvider>
+    ),
+  ],
+};

--- a/src/stories/Textarea.stories.tsx
+++ b/src/stories/Textarea.stories.tsx
@@ -1,5 +1,6 @@
 import type { Meta, StoryObj } from "@storybook/react";
 import Textarea from "@/components/common/Textarea";
+import { ThemeProvider } from "next-themes";
 
 const meta = {
   title: "common/Textarea",
@@ -11,20 +12,21 @@ const meta = {
   argTypes: {
     className: {
       control: "text",
-      type: "string",
       description:
         "옵셔널한 값으로 필요한 경우 className을 통해 Textarea에 추가적인 tailwindCSS 속성을 부여합니다.",
     },
-    placeholder: { control: "text", type: "string" },
-    value: { control: "text", type: "string" },
+    placeholder: {
+      control: "text",
+      description: "플레이스홀더 텍스트",
+      defaultValue: "내용을 입력해 주세요.",
+    },
+    value: { control: "text", type: "string", description: "인풋 밸류" },
     disabled: {
       control: "boolean",
-      type: "boolean",
       description: "옵셔널한 값으로 disabled 상태가 필요할 때 사용합니다.",
     },
     required: {
       control: "boolean",
-      type: "boolean",
       description: "옵셔널한 값으로 required 체크가 필요할 때 사용합니다.",
     },
   },
@@ -34,6 +36,13 @@ const meta = {
     className: "w-[300px]",
     placeholder: "내용을 입력해 주세요.",
   },
+  decorators: [
+    (Story) => (
+      <ThemeProvider>
+        <Story />
+      </ThemeProvider>
+    ),
+  ],
 } satisfies Meta<typeof Textarea>;
 
 export default meta;
@@ -59,4 +68,20 @@ export const Disabled: Story = {
   args: {
     disabled: true,
   },
+};
+
+export const DarkMode: Story = {
+  args: {},
+  parameters: {
+    backgrounds: { default: "dark" },
+  },
+  decorators: [
+    (Story) => (
+      <ThemeProvider forcedTheme="dark">
+        <div className="dark">
+          <Story />
+        </div>
+      </ThemeProvider>
+    ),
+  ],
 };

--- a/src/stories/Toggle.stories.tsx
+++ b/src/stories/Toggle.stories.tsx
@@ -1,0 +1,63 @@
+import type { Meta, StoryObj } from "@storybook/react";
+import { Toggle } from "@/app/me/(me-layout)/setting/_components/EmailToggle";
+import { ThemeProvider } from "next-themes";
+
+const meta = {
+  title: "common/Toggle",
+  component: Toggle,
+  parameters: {
+    layout: "centered",
+  },
+  tags: ["autodocs"],
+  argTypes: {
+    disabled: {
+      control: "boolean",
+      description: "토글 사용 가능 여부",
+    },
+  },
+  args: {
+    disabled: false,
+  },
+  decorators: [
+    (Story) => (
+      <ThemeProvider>
+        <Story />
+      </ThemeProvider>
+    ),
+  ],
+} satisfies Meta<typeof Toggle>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
+  args: {},
+};
+
+export const Checked: Story = {
+  args: {
+    checked: true,
+  },
+};
+
+export const Disabled: Story = {
+  args: {
+    disabled: true,
+  },
+};
+
+export const DarkMode: Story = {
+  args: {},
+  parameters: {
+    backgrounds: { default: "dark" },
+  },
+  decorators: [
+    (Story) => (
+      <ThemeProvider forcedTheme="dark">
+        <div className="dark">
+          <Story />
+        </div>
+      </ThemeProvider>
+    ),
+  ],
+};

--- a/src/stories/UserPic.stories.tsx
+++ b/src/stories/UserPic.stories.tsx
@@ -1,0 +1,47 @@
+import type { Meta, StoryObj } from "@storybook/react";
+import UserPic from "@/components/common/UserPic";
+
+const meta: Meta<typeof UserPic> = {
+  title: "common/UserPic",
+  component: UserPic,
+  parameters: {
+    layout: "centered",
+  },
+  tags: ["autodocs"],
+  argTypes: {
+    image: {
+      control: "text",
+      description: "이미지 경로",
+      defaultValue: "https://picsum.photos/100/100",
+    },
+    name: {
+      control: "text",
+      description: "이미지 alt 속성에 사용될 유저 이름",
+    },
+    size: {
+      control: "radio",
+      options: ["small", "large"],
+      description: "이미지 사이즈",
+      defaultValue: "large",
+    },
+  },
+};
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Large: Story = {
+  args: {
+    size: "large",
+    image: "https://picsum.photos/100/100",
+    name: "john",
+  },
+};
+
+export const Small: Story = {
+  args: {
+    size: "small",
+    image: "https://picsum.photos/100/100",
+    name: "john",
+  },
+};

--- a/src/types/library.d.ts
+++ b/src/types/library.d.ts
@@ -13,10 +13,8 @@ export type FilterType = {
 };
 
 export type LibraryState = {
-  status: {
-    isLoading: boolean;
-    error: string | null;
-  };
+  status: "IDLE" | "LOADING" | "SUCCESS" | "ERROR";
+  error: string | null;
   libraryState: FilterType;
   ITEMS_PER_PAGE: number;
   currentPage: number;

--- a/src/types/scrap.d.ts
+++ b/src/types/scrap.d.ts
@@ -9,7 +9,7 @@ export type Article = {
 };
 
 export type ScrapState = {
-  isLoading: boolean;
+  status: "IDLE" | "LOADING" | "SUCCESS" | "ERROR";
   error: string | null;
   scraps: Article[];
   ITEMS_PER_PAGE: number;


### PR DESCRIPTION
## Description
- 일부 컴포넌트의 `stories`를 추가했습니다. 다크모드 `addon` 사용시 별도로 `hook`을 `decorator` 또는 `template`에 삽입해야 하는 컴포넌트에서 에러가 발생해서 종류에 `DarkMode`를 별도로 추가하는 방향으로 작성해두었습니다. 다른 분들것도 일괄적으로 수정할까 하다가, 직접 보고 작성해보시는게 좋지않을까 싶어서 일단 두었습니다!! (극히 일부 에러같은 경우 수정)
- `repositoryList`, `articleList` 등 초기 화면에 값이 없을때 무조건 데이터 없음 화면을 띄우는 오류를 수정했습니다. + 타입 및 스토어 수정 
- 일부 컴포넌트 `css` 속성을 수정했습니다. 
- 컴포넌트 중 값을 `props`로 받아오지 않고 자체적으로 `session`에서 가져오는 컴포넌트는 `stories` 작성 하지 않았습니다 ㅠㅠ 이건 뭐가 좋은 방향인지 잘 모르겠네용

## Changes Made
- `stories` 수정 및 추가
- `css` 수정 
- 리스트 아이템 에러 수정 
- `storybook` 다크모드 `bg` 컬러 변경 

## Screenshots

## IssueNumber

해당 이슈 넘버 ( # )
